### PR TITLE
Visual debugger

### DIFF
--- a/src/java/generator/VisualDebugger.java
+++ b/src/java/generator/VisualDebugger.java
@@ -4,9 +4,7 @@ import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.awt.image.ColorModel;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import map.BinaryMask;
 import map.FloatMask;
@@ -14,11 +12,14 @@ import map.Mask;
 
 public class VisualDebugger {
 
-	public static final boolean ENABLED = false;// when enabled, mask concurrency is disabled
+	/** When enabled, mask concurrency is disabled.
+	 */
+	public static final boolean ENABLED = false;
 	
-	// If false, color representation of float masks is scaled to include negative ranges.
-	// If true, all negative values are colored as checkerboard, leaving more color space
-	// for positive numbers.
+	/** If false, color representation of float masks is scaled to include negative ranges.
+	 * If true, all negative values are colored as checkerboard, leaving more color space
+	 * for positive numbers.
+	 */
 	public static boolean ignoreNegativeRange = false;
 	
 	private static boolean isDrawAllMasks = false;

--- a/src/java/generator/VisualDebugger.java
+++ b/src/java/generator/VisualDebugger.java
@@ -20,7 +20,6 @@ public class VisualDebugger {
 	public static boolean ignoreNegativeRange = false;
 	
 	private static boolean isRecordingAllMasks = false;
-	private static BufferedImage currentImage = new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB);
 	private static Set<Integer> whitelistMasks = null;
 	
 	public static void whitelistMask(Mask binaryOrFloatMask) {
@@ -28,10 +27,6 @@ public class VisualDebugger {
 			whitelistMasks = new HashSet<>();
 		}
 		whitelistMasks.add(binaryOrFloatMask.hashCode());
-	}
-	
-	public static void start() {
-		VisualDebuggerGui.createGui(new VisualDebuggerGui.ImagePanel(() -> currentImage, 10));
 	}
 	
 	public static void startRecordAll() {
@@ -149,7 +144,7 @@ public class VisualDebugger {
 	private static void visualize(ImageSource imageSource, int size, String maskName) {
 		int perPixelSize = calculateAutoZoom(size);
 		int imageSize = size * perPixelSize;
-		currentImage = new BufferedImage(imageSize, imageSize, BufferedImage.TYPE_INT_RGB);
+		BufferedImage currentImage = new BufferedImage(imageSize, imageSize, BufferedImage.TYPE_INT_RGB);
 		// iterate source pixels
 		for (int y = 0; y < size; y++) {
 			for (int x = 0; x < size; x++) {
@@ -164,7 +159,11 @@ public class VisualDebugger {
 				}
 			}
 		}
-		VisualDebuggerGui.update("Mask: " + maskName + ", Zoom: x" + perPixelSize);
+		if (!VisualDebuggerGui.isCreated()) {
+			VisualDebuggerGui.createGui();
+		}
+		VisualDebuggerGui.update("lastChanged", currentImage, perPixelSize);
+		VisualDebuggerGui.update(maskName, currentImage, perPixelSize);
 	}
 	
 	private static int calculateAutoZoom(int imageSize) {

--- a/src/java/generator/VisualDebugger.java
+++ b/src/java/generator/VisualDebugger.java
@@ -1,0 +1,136 @@
+package generator;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.GraphicsConfiguration;
+import java.awt.Insets;
+import java.awt.event.WindowEvent;
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
+
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.WindowConstants;
+
+import map.BinaryMask;
+import map.FloatMask;
+
+public class VisualDebugger {
+
+	public static boolean ENABLED = false;// disables mask concurrency
+	public static int perPixelSize = 3;// scale factor for debug image
+	
+	private static boolean isRecording = false;
+	private static BufferedImage currentImage = new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB);
+	private static GraphicsConfiguration gc;
+	private static JFrame frame;
+	
+	// PUBLIC
+	
+	static void startRecording() {
+		isRecording = true;
+		if (frame == null) {
+			frame = new JFrame(gc);
+			JPanel panel = new JPanel() {
+				@Override
+		        protected void paintComponent(Graphics g) {				
+		            super.paintComponent(g);
+		            Graphics2D g2d = (Graphics2D) g.create();
+	                int x = (getWidth() - currentImage.getWidth()) / 2;
+	                int y = (getHeight() - currentImage.getHeight()) / 2;
+	                g2d.drawImage(currentImage, x, y, this);
+	                g2d.dispose();
+		        }
+				@Override
+				public Dimension getPreferredSize() {
+					return new Dimension(currentImage.getWidth(), currentImage.getHeight());
+				}
+			};
+			frame.add(panel);
+			frame.setVisible(true);
+			frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+			setFrameSize();
+		}
+	}
+	
+	static void stopRecording() {
+		isRecording = false;
+	}
+	
+	public static void visualizeMask(BinaryMask mask) {
+		if (!ENABLED || !isRecording) return;
+		visualize((x, y) -> {
+			return mask.get(x, y) ? Color.BLACK.getRGB() : Color.WHITE.getRGB();
+		}, mask.getSize());
+	}
+	
+	public static void visualizeMask(FloatMask mask) {
+		if (!ENABLED || !isRecording) return;
+		// TODO untested
+		visualize((x, y) -> {
+			float value = mask.get(x, y);
+			// if |value| <  1, scale white to black
+			// if |value| 1-10, scale green to red
+			// if |value| > 10, just output blue
+			if (value >= -1 && value <= 1) {
+				float normalized = ((value + 1) / 2);// map to 0 to 1
+				int singleColor = ((int) (normalized * 255)) & 0xFF;
+				return 0xFF_00_00_00
+						& (singleColor << 16)
+						& (singleColor << 8)
+						& (singleColor);
+			}
+			else if (value >= -10 && value <= 10) {
+				float normalized = ((value + 10) / 20);// map to 0 to 1
+				int green = ((int) (255 - (normalized * 255))) & 0xFF;
+				int red = ((int) (normalized * 255)) & 0xFF;
+				return 0xFF_00_00_00
+						& (red << 16)
+						& (green << 8);
+			} else {
+				return 0xFF_00_00_FF;
+			}
+		}, mask.getSize());
+	}
+	
+	// PRIVATE
+	
+	@FunctionalInterface
+	private interface ImageSource {
+		/**
+		 * @return Color (A)RGB, see {@link ColorModel#getRGBdefault()}, alpha will be ignored.
+		 */
+		public int get(int x, int y);
+	}
+	
+	private static void visualize(ImageSource imageSource, int size) {
+		int imageSize = size * perPixelSize;
+		currentImage = new BufferedImage(imageSize, imageSize, BufferedImage.TYPE_INT_RGB);
+		// iterate source pixels
+		for (int y = 0; y < size; y++) {
+			for (int x = 0; x < size; x++) {
+				int color = imageSource.get(x, y);
+				// scale source pixel to filled rectangle so its possible to see stuff
+				for (int yInner = 0; yInner < perPixelSize; yInner++) {
+					for (int xInner = 0; xInner < perPixelSize; xInner++) {
+						int drawX = (x * perPixelSize) + xInner;
+						int drawY = (y * perPixelSize) + yInner;
+						currentImage.setRGB(drawX, drawY, color);
+					}
+				}
+			}
+		}
+		
+		frame.repaint();
+		setFrameSize();
+	}
+	
+	private static void setFrameSize() {
+		Insets insets = frame.getInsets();
+		int insetsWidth = insets.left + insets.right + 10;
+		int insetsHeight = insets.top + insets.bottom + 10;
+		frame.setSize(insetsWidth + currentImage.getWidth(), insetsHeight + currentImage.getHeight());
+	}
+}

--- a/src/java/generator/VisualDebugger.java
+++ b/src/java/generator/VisualDebugger.java
@@ -3,7 +3,9 @@ package generator;
 import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.awt.image.ColorModel;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import map.BinaryMask;
@@ -20,13 +22,17 @@ public class VisualDebugger {
 	public static boolean ignoreNegativeRange = false;
 	
 	private static boolean isDrawAllMasks = false;
-	private static Set<Integer> drawMasksWhitelist = null;// whitelisted masks are always drawn
+	private static Map<Integer, String> drawMasksWhitelist = null;
 	
 	public static void whitelistMask(Mask binaryOrFloatMask) {
+		whitelistMask(binaryOrFloatMask, "" + binaryOrFloatMask.hashCode());
+	}
+	
+	public static void whitelistMask(Mask binaryOrFloatMask, String name) {
 		if (drawMasksWhitelist == null) {
-			drawMasksWhitelist = new HashSet<>();
+			drawMasksWhitelist = new HashMap<>();
 		}
-		drawMasksWhitelist.add(binaryOrFloatMask.hashCode());
+		drawMasksWhitelist.put(binaryOrFloatMask.hashCode(), name);
 	}
 	
 	public static void startRecordAll() {
@@ -43,7 +49,7 @@ public class VisualDebugger {
 		}
 		visualize((x, y) -> {
 			return mask.get(x, y) ? Color.BLACK.getRGB() : Color.WHITE.getRGB();
-		}, mask.getSize(), "" + mask.hashCode());
+		}, mask.getSize(), mask.hashCode());
 	}
 	
 	public static void visualizeMask(FloatMask mask) {
@@ -95,7 +101,7 @@ public class VisualDebugger {
 			} else {
 				return 0xFF_00_00_00;
 			}
-		}, mask.getSize(), "" + mask.hashCode());
+		}, mask.getSize(), mask.hashCode());
 	}
 	
 	private static boolean shouldRecord(Mask mask) {
@@ -103,7 +109,7 @@ public class VisualDebugger {
 			return false;
 		}
 		return (drawMasksWhitelist == null && isDrawAllMasks)
-				|| (drawMasksWhitelist != null && drawMasksWhitelist.contains(mask.hashCode()));
+				|| (drawMasksWhitelist != null && drawMasksWhitelist.containsKey(mask.hashCode()));
 	}
 	
 	/**
@@ -136,7 +142,7 @@ public class VisualDebugger {
 		public int get(int x, int y);
 	}
 	
-	private static void visualize(ImageSource imageSource, int size, String maskName) {
+	private static void visualize(ImageSource imageSource, int size, int maskHash) {
 		int perPixelSize = calculateAutoZoom(size);
 		int imageSize = size * perPixelSize;
 		BufferedImage currentImage = new BufferedImage(imageSize, imageSize, BufferedImage.TYPE_INT_RGB);
@@ -158,6 +164,7 @@ public class VisualDebugger {
 			VisualDebuggerGui.createGui();
 		}
 		VisualDebuggerGui.update("lastChanged", currentImage, perPixelSize);
+		String maskName = drawMasksWhitelist.getOrDefault(maskHash, String.valueOf(maskHash));
 		VisualDebuggerGui.update(maskName, currentImage, perPixelSize);
 	}
 	

--- a/src/java/generator/VisualDebugger.java
+++ b/src/java/generator/VisualDebugger.java
@@ -12,29 +12,29 @@ import map.Mask;
 
 public class VisualDebugger {
 
-	public static boolean ENABLED = false;// when enabled, mask concurrency is disabled
+	public static final boolean ENABLED = false;// when enabled, mask concurrency is disabled
 	
-	// If true, color representation of float masks is scaled to include negative ranges.
-	// If false, all negative values are colored as checkerboard, leaving more color space
+	// If false, color representation of float masks is scaled to include negative ranges.
+	// If true, all negative values are colored as checkerboard, leaving more color space
 	// for positive numbers.
 	public static boolean ignoreNegativeRange = false;
 	
-	private static boolean isRecordingAllMasks = false;
-	private static Set<Integer> whitelistMasks = null;
+	private static boolean isDrawAllMasks = false;
+	private static Set<Integer> drawMasksWhitelist = null;// whitelisted masks are always drawn
 	
 	public static void whitelistMask(Mask binaryOrFloatMask) {
-		if (whitelistMasks == null) {
-			whitelistMasks = new HashSet<>();
+		if (drawMasksWhitelist == null) {
+			drawMasksWhitelist = new HashSet<>();
 		}
-		whitelistMasks.add(binaryOrFloatMask.hashCode());
+		drawMasksWhitelist.add(binaryOrFloatMask.hashCode());
 	}
 	
 	public static void startRecordAll() {
-		isRecordingAllMasks = true;
+		isDrawAllMasks = true;
 	}
 	
 	public static void stopRecordAll() {
-		isRecordingAllMasks = false;
+		isDrawAllMasks = false;
 	}
 	
 	public static void visualizeMask(BinaryMask mask) {
@@ -94,7 +94,7 @@ public class VisualDebugger {
 				}
 			}
 			if (value < 0) {
-				// checkerboard / dither
+				// checkerboard
 				return (x + y) % 2 == 0 ?
 						0xFF_66_66_66 : 0xDD_DD_DD_DD ;
 			} else {
@@ -107,8 +107,8 @@ public class VisualDebugger {
 		if (!ENABLED) {
 			return false;
 		}
-		return (whitelistMasks == null && isRecordingAllMasks)
-				|| (whitelistMasks != null && whitelistMasks.contains(mask.hashCode()));
+		return (drawMasksWhitelist == null && isDrawAllMasks)
+				|| (drawMasksWhitelist != null && drawMasksWhitelist.contains(mask.hashCode()));
 	}
 	
 	/**

--- a/src/java/generator/VisualDebugger.java
+++ b/src/java/generator/VisualDebugger.java
@@ -50,21 +50,18 @@ public class VisualDebugger {
 		if (!shouldRecord(mask)) {
 			return;
 		}
+		ImageSource checkerBoard = (x , y) -> {
+			return (x + y) % 2 == 0 ? 0xFF_66_66_66 : 0xDD_DD_DD_DD ;
+		};
 		visualize((x, y) -> {
 			float value = mask.get(x, y);
-			// if |value| <  1, scale white to black
-			// if |value| 1-10, scale green to red
-			// if |value| 10-50, dark blue to blue
-			// if |value| > 100, just output blue
 			
 			if (ignoreNegativeRange && value < 0) {
-				// checkerboard
-				return (x + y) % 2 == 0 ?
-						0xFF_66_66_66 : 0xDD_DD_DD_DD ;
+				return checkerBoard.get(x, y);
 			}
-			// For each range we interpolate from color white to the color given in the corresponding mask.
-			// Ranges must be ordered smallest to biggest. Anything bigger than biggest range becomes black.
-			// Anything smaller than smallest becomes checkerboard.
+			// For each range we interpolate from color white to the color given in the corresponding array.
+			// Ranges must be positive and ordered smallest to biggest. Anything bigger than biggest range
+			// becomes black. Anything smaller than smallest becomes checkerboard.
 			int[] colors = new int[] {
 					0xFF_FF_00_00,
 					0xFF_00_FF_00,
@@ -94,9 +91,7 @@ public class VisualDebugger {
 				}
 			}
 			if (value < 0) {
-				// checkerboard
-				return (x + y) % 2 == 0 ?
-						0xFF_66_66_66 : 0xDD_DD_DD_DD ;
+				return checkerBoard.get(x, y);
 			} else {
 				return 0xFF_00_00_00;
 			}

--- a/src/java/generator/VisualDebuggerGui.java
+++ b/src/java/generator/VisualDebuggerGui.java
@@ -43,7 +43,7 @@ public class VisualDebuggerGui {
 		}
 		
 		@Override
-        protected void paintComponent(Graphics g) {
+		protected void paintComponent(Graphics g) {
             super.paintComponent(g);
             Graphics2D g2d = (Graphics2D) g.create();
             BufferedImage currentImage = image;

--- a/src/java/generator/VisualDebuggerGui.java
+++ b/src/java/generator/VisualDebuggerGui.java
@@ -1,0 +1,80 @@
+package generator;
+
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.util.function.Supplier;
+
+import javax.swing.BoxLayout;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.WindowConstants;
+
+public class VisualDebuggerGui {
+
+	/**
+	 * Panel that shows the given image.
+	 * Call {@link JPanel#revalidate()} to resize panel when image size changes.
+	 * Call {@link JPanel#repaint()} to update when image content changes.
+	 */
+	@SuppressWarnings("serial")
+	public static class ImagePanel extends JPanel {
+		private Supplier<BufferedImage> image;
+		private int padding;
+		
+		public ImagePanel(Supplier<BufferedImage> image, int padding) {
+			this.image = image;
+			this.padding = padding;
+		}
+		@Override
+        protected void paintComponent(Graphics g) {
+            super.paintComponent(g);
+            Graphics2D g2d = (Graphics2D) g.create();
+            BufferedImage currentImage = image.get();
+            int x = (getWidth() - currentImage.getWidth()) / 2;
+            int y = (getHeight() - currentImage.getHeight()) / 2;
+            g2d.drawImage(currentImage, x, y, this);
+            g2d.dispose();
+        }
+		@Override
+		public Dimension getPreferredSize() {
+			BufferedImage currentImage = image.get();
+			return new Dimension(currentImage.getWidth() + padding, currentImage.getHeight() + padding);
+		}
+		@Override
+		public Dimension getMinimumSize() {
+			return getPreferredSize();
+		}
+	}
+	
+	private static JFrame frame;
+	private static Container contentPane;
+	private static JPanel canvas;
+	
+	public static void createGui(JPanel canvas) {
+		if (frame != null) {
+			return;
+		}
+		VisualDebuggerGui.canvas = canvas;
+		frame = new JFrame();
+		contentPane = frame.getContentPane();
+		contentPane.setLayout(new BoxLayout(contentPane, BoxLayout.X_AXIS));
+		contentPane.add(canvas);
+		frame.pack();
+		frame.setVisible(true);
+		frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+	}
+	
+	public static void update(String title) {
+		canvas.revalidate();
+		canvas.repaint();
+		frame.pack();
+		frame.setTitle(title);
+	}
+	
+	public static void setTitle(String title) {
+		frame.setTitle(title);
+	}
+}

--- a/src/java/generator/VisualDebuggerGui.java
+++ b/src/java/generator/VisualDebuggerGui.java
@@ -5,15 +5,22 @@ import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
-import java.util.function.Supplier;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.swing.BoxLayout;
+import javax.swing.DefaultListModel;
 import javax.swing.JFrame;
+import javax.swing.JList;
 import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.ListSelectionModel;
 import javax.swing.WindowConstants;
 
 public class VisualDebuggerGui {
 
+	public static final boolean AUTO_SELECT_NEW_MASKS = false;
+	
 	/**
 	 * Panel that shows the given image.
 	 * Call {@link JPanel#revalidate()} to resize panel when image size changes.
@@ -21,18 +28,25 @@ public class VisualDebuggerGui {
 	 */
 	@SuppressWarnings("serial")
 	public static class ImagePanel extends JPanel {
-		private Supplier<BufferedImage> image;
-		private int padding;
+		private final int padding = 10;
 		
-		public ImagePanel(Supplier<BufferedImage> image, int padding) {
+		private BufferedImage image;
+		private int zoomFactor;
+		
+		public void setViewModel(BufferedImage image, int zoomFactor) {
 			this.image = image;
-			this.padding = padding;
+			this.zoomFactor = zoomFactor;
 		}
+		
+		public int getZoomFactor() {
+			return zoomFactor;
+		}
+		
 		@Override
         protected void paintComponent(Graphics g) {
             super.paintComponent(g);
             Graphics2D g2d = (Graphics2D) g.create();
-            BufferedImage currentImage = image.get();
+            BufferedImage currentImage = image;
             int x = (getWidth() - currentImage.getWidth()) / 2;
             int y = (getHeight() - currentImage.getHeight()) / 2;
             g2d.drawImage(currentImage, x, y, this);
@@ -40,7 +54,7 @@ public class VisualDebuggerGui {
         }
 		@Override
 		public Dimension getPreferredSize() {
-			BufferedImage currentImage = image.get();
+			BufferedImage currentImage = image;
 			return new Dimension(currentImage.getWidth() + padding, currentImage.getHeight() + padding);
 		}
 		@Override
@@ -49,32 +63,105 @@ public class VisualDebuggerGui {
 		}
 	}
 	
+	public static class MaskListItem {
+		public final String maskName;
+		public MaskListItem(String maskName) {
+			this.maskName = maskName;
+		}
+		@Override
+		public int hashCode() {
+			return maskName.hashCode();
+		}
+		@Override
+		public boolean equals(Object other) {
+			if (other instanceof MaskListItem) {
+				return this.maskName.equals(((MaskListItem)other).maskName);
+			}
+			return false;
+		}
+		@Override
+		public String toString() {
+			return "  " + maskName + "  ";
+		}
+	}
+	
 	private static JFrame frame;
 	private static Container contentPane;
-	private static JPanel canvas;
+	private static JList<MaskListItem> list;
+	private static JPanel canvasContainer;
 	
-	public static void createGui(JPanel canvas) {
+	private static DefaultListModel<MaskListItem> listModel = new DefaultListModel<>();
+	private static Map<String, ImagePanel> maskNameToCanvas = new HashMap<>();
+	
+	public static boolean isCreated() {
+		return frame != null;
+	}
+	
+	public static void createGui() {
 		if (frame != null) {
 			return;
 		}
-		VisualDebuggerGui.canvas = canvas;
 		frame = new JFrame();
 		contentPane = frame.getContentPane();
 		contentPane.setLayout(new BoxLayout(contentPane, BoxLayout.X_AXIS));
-		contentPane.add(canvas);
+		
+		createList();
+		canvasContainer = new JPanel();
+		contentPane.add(canvasContainer);
+		
 		frame.pack();
 		frame.setVisible(true);
 		frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
 	}
 	
-	public static void update(String title) {
+	private static void createList() {
+		list = new JList<>(listModel);
+		list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+		list.addListSelectionListener(event -> {
+			if (!event.getValueIsAdjusting()) {
+				MaskListItem selectedItem = list.getSelectedValue();
+				onSelect(selectedItem.maskName);
+			}
+		});
+		
+		JScrollPane listScroller = new JScrollPane(list);
+		listScroller.setMinimumSize(new Dimension(100, 0));
+		contentPane.add(listScroller);
+	}
+	
+	public static void update(String uniqueMaskName, BufferedImage image, int zoomFactor) {
+		boolean isNewMask = !maskNameToCanvas.containsKey(uniqueMaskName);
+		if (isNewMask) {
+			maskNameToCanvas.put(uniqueMaskName, new ImagePanel());
+			listModel.addElement(new MaskListItem(uniqueMaskName));
+		}
+		ImagePanel canvas = maskNameToCanvas.get(uniqueMaskName);
+		canvas.setViewModel(image, zoomFactor);
+		if (isNewMask && (listModel.getSize() == 1 || AUTO_SELECT_NEW_MASKS)) {
+			list.setSelectedIndex(listModel.getSize() - 1);
+		} else {
+			MaskListItem selected = list.getSelectedValue();
+			if (selected != null && selected.maskName.equals(uniqueMaskName)) {
+				updateVisibleCanvas(uniqueMaskName, canvas);
+			}
+		}
+	}
+	
+	public static void remove(String uniqueMaskName) {
+		listModel.removeElement(new MaskListItem(uniqueMaskName));
+	}
+	
+	private static void onSelect(String uniqueMaskName) {
+		ImagePanel selectedCanvas = maskNameToCanvas.get(uniqueMaskName);
+		canvasContainer.removeAll();
+		canvasContainer.add(selectedCanvas);
+		updateVisibleCanvas(uniqueMaskName, selectedCanvas);
+	}
+	
+	private static void updateVisibleCanvas(String maskName, ImagePanel canvas) {
 		canvas.revalidate();
 		canvas.repaint();
 		frame.pack();
-		frame.setTitle(title);
-	}
-	
-	public static void setTitle(String title) {
-		frame.setTitle(title);
+		frame.setTitle("Mask: " + maskName + ", Zoom: x" + canvas.getZoomFactor());
 	}
 }

--- a/src/java/generator/VisualDebuggerGui.java
+++ b/src/java/generator/VisualDebuggerGui.java
@@ -46,14 +46,14 @@ public class VisualDebuggerGui {
 		
 		@Override
 		protected void paintComponent(Graphics g) {
-            super.paintComponent(g);
-            Graphics2D g2d = (Graphics2D) g.create();
-            BufferedImage currentImage = image;
-            int x = (getWidth() - currentImage.getWidth()) / 2;
-            int y = (getHeight() - currentImage.getHeight()) / 2;
-            g2d.drawImage(currentImage, x, y, this);
-            g2d.dispose();
-        }
+			super.paintComponent(g);
+			Graphics2D g2d = (Graphics2D) g.create();
+			BufferedImage currentImage = image;
+			int x = (getWidth() - currentImage.getWidth()) / 2;
+			int y = (getHeight() - currentImage.getHeight()) / 2;
+			g2d.drawImage(currentImage, x, y, this);
+			g2d.dispose();
+		}
 		@Override
 		public Dimension getPreferredSize() {
 			BufferedImage currentImage = image;

--- a/src/java/generator/VisualDebuggerGui.java
+++ b/src/java/generator/VisualDebuggerGui.java
@@ -17,6 +17,8 @@ import javax.swing.JScrollPane;
 import javax.swing.ListSelectionModel;
 import javax.swing.WindowConstants;
 
+import lombok.Value;
+
 public class VisualDebuggerGui {
 
 	public static final boolean AUTO_SELECT_NEW_MASKS = false;
@@ -63,22 +65,9 @@ public class VisualDebuggerGui {
 		}
 	}
 	
+	@Value
 	public static class MaskListItem {
-		public final String maskName;
-		public MaskListItem(String maskName) {
-			this.maskName = maskName;
-		}
-		@Override
-		public int hashCode() {
-			return maskName.hashCode();
-		}
-		@Override
-		public boolean equals(Object other) {
-			if (other instanceof MaskListItem) {
-				return this.maskName.equals(((MaskListItem)other).maskName);
-			}
-			return false;
-		}
+		String maskName;
 		@Override
 		public String toString() {
 			return "  " + maskName + "  ";

--- a/src/java/map/BinaryMask.java
+++ b/src/java/map/BinaryMask.java
@@ -11,6 +11,8 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Random;
 
+import generator.VisualDebugger;
+
 public strictfp class BinaryMask {
 	private boolean[][] mask;
 	private final Random random;
@@ -65,6 +67,7 @@ public strictfp class BinaryMask {
 			}
 		}
 		applySymmetry();
+		VisualDebugger.visualizeMask(this);
 		return this;
 	}
 
@@ -74,6 +77,7 @@ public strictfp class BinaryMask {
 				mask[x][y] = !mask[x][y];
 			}
 		}
+		VisualDebugger.visualizeMask(this);
 		return this;
 	}
 
@@ -89,6 +93,7 @@ public strictfp class BinaryMask {
 			}
 		}
 		mask = largeMask;
+		VisualDebugger.visualizeMask(this);
 		return this;
 	}
 
@@ -108,6 +113,7 @@ public strictfp class BinaryMask {
 			}
 		}
 		mask = smallMask;
+		VisualDebugger.visualizeMask(this);
 		return this;
 	}
 
@@ -135,6 +141,7 @@ public strictfp class BinaryMask {
 			}
 		}
 		mask = maskCopy;
+		VisualDebugger.visualizeMask(this);
 		return this;
 	}
 
@@ -176,6 +183,7 @@ public strictfp class BinaryMask {
 			}
 		}
 		mask = maskCopy;
+		VisualDebugger.visualizeMask(this);
 		return this;
 	}
 
@@ -192,6 +200,7 @@ public strictfp class BinaryMask {
 		}
 		mask = maskCopy;
 		applySymmetry();
+		VisualDebugger.visualizeMask(this);
 		return this;
 	}
 
@@ -212,6 +221,7 @@ public strictfp class BinaryMask {
 		}
 		mask = maskCopy;
 		applySymmetry();
+		VisualDebugger.visualizeMask(this);
 		return this;
 	}
 
@@ -233,6 +243,7 @@ public strictfp class BinaryMask {
 			}
 		}
 		mask = maskCopy;
+		VisualDebugger.visualizeMask(this);
 		return this;
 	}
 
@@ -273,6 +284,7 @@ public strictfp class BinaryMask {
 			}
 		}
 		mask = maskCopy;
+		VisualDebugger.visualizeMask(this);
 		return this;
 	}
 
@@ -289,6 +301,7 @@ public strictfp class BinaryMask {
 			}
 		}
 		mask = maskCopy;
+		VisualDebugger.visualizeMask(this);
 		return this;
 	}
 
@@ -305,6 +318,7 @@ public strictfp class BinaryMask {
 			}
 		}
 		mask = maskCopy;
+		VisualDebugger.visualizeMask(this);
 		return this;
 	}
 
@@ -323,6 +337,7 @@ public strictfp class BinaryMask {
 				}
 			}
 		}
+		VisualDebugger.visualizeMask(this);
 		return this;
 	}
 	
@@ -335,6 +350,7 @@ public strictfp class BinaryMask {
 				mask[getSize() - 1 - b][a] = false;
 			}
 		}
+		VisualDebugger.visualizeMask(this);
 		return this;
 	}
 	

--- a/src/java/map/BinaryMask.java
+++ b/src/java/map/BinaryMask.java
@@ -397,4 +397,8 @@ public strictfp class BinaryMask implements Mask {
 	public void startVisualDebugger() {
 		VisualDebugger.whitelistMask(this);
 	}
+	
+	public void startVisualDebugger(String maskName) {
+		VisualDebugger.whitelistMask(this, maskName);
+	}
 }

--- a/src/java/map/BinaryMask.java
+++ b/src/java/map/BinaryMask.java
@@ -13,7 +13,7 @@ import java.util.Random;
 
 import generator.VisualDebugger;
 
-public strictfp class BinaryMask {
+public strictfp class BinaryMask implements Mask {
 	private boolean[][] mask;
 	private final Random random;
 	private final Symmetry symmetry = Symmetry.POINT;
@@ -391,5 +391,10 @@ public strictfp class BinaryMask {
 		}
 
 		out.close();
+	}
+	
+	@Override
+	public void startVisualDebugger() {
+		VisualDebugger.whitelistMask(this);
 	}
 }

--- a/src/java/map/ConcurrentBinaryMask.java
+++ b/src/java/map/ConcurrentBinaryMask.java
@@ -15,7 +15,7 @@ public strictfp class ConcurrentBinaryMask implements ConcurrentMask {
 	public ConcurrentBinaryMask(int size, long seed, String name) {
 		this.binaryMask = new BinaryMask(size, seed);
 		this.name = name;
-		
+
 		Pipeline.add(this, Arrays.asList(), res ->
 				Arrays.asList()
 		);

--- a/src/java/map/ConcurrentBinaryMask.java
+++ b/src/java/map/ConcurrentBinaryMask.java
@@ -5,6 +5,8 @@ import util.Pipeline;
 import java.nio.file.Path;
 import java.util.Arrays;
 
+import generator.VisualDebugger;
+
 public strictfp class ConcurrentBinaryMask implements ConcurrentMask {
 
 	private BinaryMask binaryMask;
@@ -22,7 +24,7 @@ public strictfp class ConcurrentBinaryMask implements ConcurrentMask {
 	public ConcurrentBinaryMask(ConcurrentBinaryMask mask, long seed, String name) {
 		this.name = name;
 
-		if(name.equals("mocked")) {
+		if(name.equals("mocked") || VisualDebugger.ENABLED) {
 			this.binaryMask = new BinaryMask(mask.getBinaryMask(), seed);
 		} else {
 			Pipeline.add(this, Arrays.asList(mask), res -> {
@@ -33,90 +35,150 @@ public strictfp class ConcurrentBinaryMask implements ConcurrentMask {
 	}
 
 	public ConcurrentBinaryMask randomize(float density) {
+		if (VisualDebugger.ENABLED) {
+			binaryMask.randomize(density);
+			return this;
+		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.binaryMask.randomize(density)
 		);
 	}
 
 	public ConcurrentBinaryMask invert() {
+		if (VisualDebugger.ENABLED) {
+			binaryMask.invert();
+			return this;
+		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.binaryMask.invert()
 		);
 	}
 
 	public ConcurrentBinaryMask enlarge(int size) {
+		if (VisualDebugger.ENABLED) {
+			binaryMask.enlarge(size);
+			return this;
+		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.binaryMask.enlarge(size)
 		);
 	}
 
 	public ConcurrentBinaryMask shrink(int size) {
+		if (VisualDebugger.ENABLED) {
+			binaryMask.shrink(size);
+			return this;
+		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.binaryMask.shrink(size)
 		);
 	}
 
 	public ConcurrentBinaryMask inflate(float radius) {
+		if (VisualDebugger.ENABLED) {
+			binaryMask.inflate(radius);
+			return this;
+		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.binaryMask.inflate(radius)
 		);
 	}
 
 	public ConcurrentBinaryMask deflate(float radius) {
+		if (VisualDebugger.ENABLED) {
+			binaryMask.deflate(radius);
+			return this;
+		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.binaryMask.deflate(radius)
 		);
 	}
 
 	public ConcurrentBinaryMask cutCorners() {
+		if (VisualDebugger.ENABLED) {
+			binaryMask.cutCorners();
+			return this;
+		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.binaryMask.cutCorners()
 		);
 	}
 
 	public ConcurrentBinaryMask acid(float strength) {
+		if (VisualDebugger.ENABLED) {
+			binaryMask.acid(strength);
+			return this;
+		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.binaryMask.acid(strength)
 		);
 	}
 
 	public ConcurrentBinaryMask outline() {
+		if (VisualDebugger.ENABLED) {
+			binaryMask.outline();
+			return this;
+		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.binaryMask.outline()
 		);
 	}
 
 	public ConcurrentBinaryMask smooth(float radius) {
+		if (VisualDebugger.ENABLED) {
+			binaryMask.smooth(radius);
+			return this;
+		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.binaryMask.smooth(radius)
 		);
 	}
 
 	public ConcurrentBinaryMask combine(ConcurrentBinaryMask other) {
+		if (VisualDebugger.ENABLED) {
+			binaryMask.combine(other.getBinaryMask());
+			return this;
+		}
 		return Pipeline.add(this, Arrays.asList(this, other), res ->
 				this.binaryMask.combine(((ConcurrentBinaryMask)res.get(1)).getBinaryMask())
 		);
 	}
 
 	public ConcurrentBinaryMask intersect(ConcurrentBinaryMask other) {
+		if (VisualDebugger.ENABLED) {
+			binaryMask.intersect(other.getBinaryMask());
+			return this;
+		}
 		return Pipeline.add(this, Arrays.asList(this, other), res ->
 				this.binaryMask.intersect(((ConcurrentBinaryMask)res.get(1)).getBinaryMask())
 		);
 	}
 
 	public ConcurrentBinaryMask minus(ConcurrentBinaryMask other) {
+		if (VisualDebugger.ENABLED) {
+			binaryMask.minus(other.getBinaryMask());
+			return this;
+		}
 		return Pipeline.add(this, Arrays.asList(this, other), res ->
 				this.binaryMask.minus(((ConcurrentBinaryMask)res.get(1)).getBinaryMask())
 		);
 	}
 
 	public ConcurrentBinaryMask fillCircle(float x, float y, float radius, boolean value) {
+		if (VisualDebugger.ENABLED) {
+			binaryMask.fillCircle(x, y, radius, value);
+			return this;
+		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.binaryMask.fillCircle(x, y, radius, value)
 		);
 	}
 
 	public ConcurrentBinaryMask trimEdge(int rimWidth) {
+		if (VisualDebugger.ENABLED) {
+			binaryMask.trimEdge(rimWidth);
+			return this;
+		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.binaryMask.trimEdge(rimWidth)
 		);

--- a/src/java/map/ConcurrentBinaryMask.java
+++ b/src/java/map/ConcurrentBinaryMask.java
@@ -15,6 +15,10 @@ public strictfp class ConcurrentBinaryMask implements ConcurrentMask {
 	public ConcurrentBinaryMask(int size, long seed, String name) {
 		this.binaryMask = new BinaryMask(size, seed);
 		this.name = name;
+		
+		Pipeline.add(this, Arrays.asList(), res ->
+				Arrays.asList()
+		);
 	}
 
 	public ConcurrentBinaryMask(ConcurrentBinaryMask mask, long seed, String name) {

--- a/src/java/map/ConcurrentBinaryMask.java
+++ b/src/java/map/ConcurrentBinaryMask.java
@@ -203,4 +203,8 @@ public strictfp class ConcurrentBinaryMask implements ConcurrentMask {
 	public String getName() {
 		return name;
 	}
+	
+	public void startVisualDebugger() {
+		VisualDebugger.whitelistMask(this.binaryMask);
+	}
 }

--- a/src/java/map/ConcurrentBinaryMask.java
+++ b/src/java/map/ConcurrentBinaryMask.java
@@ -15,10 +15,6 @@ public strictfp class ConcurrentBinaryMask implements ConcurrentMask {
 	public ConcurrentBinaryMask(int size, long seed, String name) {
 		this.binaryMask = new BinaryMask(size, seed);
 		this.name = name;
-
-		Pipeline.add(this, Arrays.asList(), res ->
-				Arrays.asList()
-		);
 	}
 
 	public ConcurrentBinaryMask(ConcurrentBinaryMask mask, long seed, String name) {
@@ -35,150 +31,90 @@ public strictfp class ConcurrentBinaryMask implements ConcurrentMask {
 	}
 
 	public ConcurrentBinaryMask randomize(float density) {
-		if (VisualDebugger.ENABLED) {
-			binaryMask.randomize(density);
-			return this;
-		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.binaryMask.randomize(density)
 		);
 	}
 
 	public ConcurrentBinaryMask invert() {
-		if (VisualDebugger.ENABLED) {
-			binaryMask.invert();
-			return this;
-		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.binaryMask.invert()
 		);
 	}
 
 	public ConcurrentBinaryMask enlarge(int size) {
-		if (VisualDebugger.ENABLED) {
-			binaryMask.enlarge(size);
-			return this;
-		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.binaryMask.enlarge(size)
 		);
 	}
 
 	public ConcurrentBinaryMask shrink(int size) {
-		if (VisualDebugger.ENABLED) {
-			binaryMask.shrink(size);
-			return this;
-		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.binaryMask.shrink(size)
 		);
 	}
 
 	public ConcurrentBinaryMask inflate(float radius) {
-		if (VisualDebugger.ENABLED) {
-			binaryMask.inflate(radius);
-			return this;
-		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.binaryMask.inflate(radius)
 		);
 	}
 
 	public ConcurrentBinaryMask deflate(float radius) {
-		if (VisualDebugger.ENABLED) {
-			binaryMask.deflate(radius);
-			return this;
-		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.binaryMask.deflate(radius)
 		);
 	}
 
 	public ConcurrentBinaryMask cutCorners() {
-		if (VisualDebugger.ENABLED) {
-			binaryMask.cutCorners();
-			return this;
-		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.binaryMask.cutCorners()
 		);
 	}
 
 	public ConcurrentBinaryMask acid(float strength) {
-		if (VisualDebugger.ENABLED) {
-			binaryMask.acid(strength);
-			return this;
-		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.binaryMask.acid(strength)
 		);
 	}
 
 	public ConcurrentBinaryMask outline() {
-		if (VisualDebugger.ENABLED) {
-			binaryMask.outline();
-			return this;
-		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.binaryMask.outline()
 		);
 	}
 
 	public ConcurrentBinaryMask smooth(float radius) {
-		if (VisualDebugger.ENABLED) {
-			binaryMask.smooth(radius);
-			return this;
-		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.binaryMask.smooth(radius)
 		);
 	}
 
 	public ConcurrentBinaryMask combine(ConcurrentBinaryMask other) {
-		if (VisualDebugger.ENABLED) {
-			binaryMask.combine(other.getBinaryMask());
-			return this;
-		}
 		return Pipeline.add(this, Arrays.asList(this, other), res ->
 				this.binaryMask.combine(((ConcurrentBinaryMask)res.get(1)).getBinaryMask())
 		);
 	}
 
 	public ConcurrentBinaryMask intersect(ConcurrentBinaryMask other) {
-		if (VisualDebugger.ENABLED) {
-			binaryMask.intersect(other.getBinaryMask());
-			return this;
-		}
 		return Pipeline.add(this, Arrays.asList(this, other), res ->
 				this.binaryMask.intersect(((ConcurrentBinaryMask)res.get(1)).getBinaryMask())
 		);
 	}
 
 	public ConcurrentBinaryMask minus(ConcurrentBinaryMask other) {
-		if (VisualDebugger.ENABLED) {
-			binaryMask.minus(other.getBinaryMask());
-			return this;
-		}
 		return Pipeline.add(this, Arrays.asList(this, other), res ->
 				this.binaryMask.minus(((ConcurrentBinaryMask)res.get(1)).getBinaryMask())
 		);
 	}
 
 	public ConcurrentBinaryMask fillCircle(float x, float y, float radius, boolean value) {
-		if (VisualDebugger.ENABLED) {
-			binaryMask.fillCircle(x, y, radius, value);
-			return this;
-		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.binaryMask.fillCircle(x, y, radius, value)
 		);
 	}
 
 	public ConcurrentBinaryMask trimEdge(int rimWidth) {
-		if (VisualDebugger.ENABLED) {
-			binaryMask.trimEdge(rimWidth);
-			return this;
-		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.binaryMask.trimEdge(rimWidth)
 		);
@@ -206,5 +142,9 @@ public strictfp class ConcurrentBinaryMask implements ConcurrentMask {
 	
 	public void startVisualDebugger() {
 		VisualDebugger.whitelistMask(this.binaryMask);
+	}
+	
+	public void startVisualDebugger(String maskName) {
+		VisualDebugger.whitelistMask(this.binaryMask, maskName);
 	}
 }

--- a/src/java/map/ConcurrentFloatMask.java
+++ b/src/java/map/ConcurrentFloatMask.java
@@ -15,7 +15,7 @@ public strictfp class ConcurrentFloatMask implements ConcurrentMask {
 	public ConcurrentFloatMask(int size, long seed, String name) {
 		this.floatMask = new FloatMask(size, seed);
 		this.name = name;
-		
+
 		Pipeline.add(this, Arrays.asList(), res ->
 				Arrays.asList()
 		);

--- a/src/java/map/ConcurrentFloatMask.java
+++ b/src/java/map/ConcurrentFloatMask.java
@@ -5,6 +5,8 @@ import util.Pipeline;
 import java.nio.file.Path;
 import java.util.Arrays;
 
+import generator.VisualDebugger;
+
 public strictfp class ConcurrentFloatMask implements ConcurrentMask {
 
 	private FloatMask floatMask;
@@ -22,7 +24,7 @@ public strictfp class ConcurrentFloatMask implements ConcurrentMask {
 	public ConcurrentFloatMask(ConcurrentFloatMask mask, long seed, String name) {
 		this.name = name;
 
-		if(name.equals("mocked")) {
+		if(name.equals("mocked") || VisualDebugger.ENABLED) {
 			this.floatMask = new FloatMask(mask.getFloatMask(), seed);
 		} else {
 			Pipeline.add(this, Arrays.asList(mask), res -> {
@@ -33,6 +35,10 @@ public strictfp class ConcurrentFloatMask implements ConcurrentMask {
 	}
 
 	public ConcurrentFloatMask init(ConcurrentBinaryMask other, float low, float high) {
+		if (VisualDebugger.ENABLED) {
+			this.floatMask.init(other.getBinaryMask(), low, high);
+			return this;
+		}
 		return Pipeline.add(this, Arrays.asList(this, other), res -> {
 				return this.floatMask.init(((ConcurrentBinaryMask) res.get(1)).getBinaryMask(), low, high);
 			}
@@ -40,36 +46,60 @@ public strictfp class ConcurrentFloatMask implements ConcurrentMask {
 	}
 
 	public ConcurrentFloatMask add(ConcurrentFloatMask other) {
+		if (VisualDebugger.ENABLED) {
+			this.floatMask.add(other.getFloatMask());
+			return this;
+		}
 		return Pipeline.add(this, Arrays.asList(this, other), res ->
 				this.floatMask.add(((ConcurrentFloatMask)res.get(1)).getFloatMask())
 		);
 	}
 
 	public ConcurrentFloatMask max(ConcurrentBinaryMask other) {
+		if (VisualDebugger.ENABLED) {
+			throw new UnsupportedOperationException();
+		}
 		return Pipeline.add(this, Arrays.asList(this, other), res ->
+				// Probably a bug, res should be BinaryMask
 				this.floatMask.max(((ConcurrentFloatMask)res.get(1)).getFloatMask())
 		);
 	}
 
 	public ConcurrentFloatMask maskToMoutains(float firstSlope, float slope, ConcurrentBinaryMask other) {
+		if (VisualDebugger.ENABLED) {
+			this.floatMask.maskToMoutains(firstSlope, slope, other.getBinaryMask());
+			return this;
+		}
 		return Pipeline.add(this, Arrays.asList(this, other), res ->
 				this.floatMask.maskToMoutains(firstSlope, slope, ((ConcurrentBinaryMask)res.get(1)).getBinaryMask())
 		);
 	}
 
 	public ConcurrentFloatMask maskToHeightmap(float slope, float underWaterSlope, int maxRepeat, ConcurrentBinaryMask other) {
+		if (VisualDebugger.ENABLED) {
+			this.floatMask.maskToHeightmap(slope, underWaterSlope, maxRepeat, other.getBinaryMask());
+			return this;
+		}
 		return Pipeline.add(this, Arrays.asList(this, other), res ->
 				this.floatMask.maskToHeightmap(slope, underWaterSlope, maxRepeat, ((ConcurrentBinaryMask)res.get(1)).getBinaryMask())
 		);
 	}
 
 	public ConcurrentFloatMask smooth(float radius) {
+		if (VisualDebugger.ENABLED) {
+			this.floatMask.smooth(radius);
+			return this;
+		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.floatMask.smooth(radius)
 		);
 	}
 
 	public ConcurrentFloatMask smooth(float radius, ConcurrentBinaryMask limiter) {
+		if (VisualDebugger.ENABLED) {
+			this.floatMask.smooth(radius, limiter.getBinaryMask());
+			return this;
+		}
 		return Pipeline.add(this, Arrays.asList(this, limiter), res ->
 				this.floatMask.smooth(radius, ((ConcurrentBinaryMask) res.get(1)).getBinaryMask())
 		);

--- a/src/java/map/ConcurrentFloatMask.java
+++ b/src/java/map/ConcurrentFloatMask.java
@@ -15,10 +15,6 @@ public strictfp class ConcurrentFloatMask implements ConcurrentMask {
 	public ConcurrentFloatMask(int size, long seed, String name) {
 		this.floatMask = new FloatMask(size, seed);
 		this.name = name;
-
-		Pipeline.add(this, Arrays.asList(), res ->
-				Arrays.asList()
-		);
 	}
 
 	public ConcurrentFloatMask(ConcurrentFloatMask mask, long seed, String name) {
@@ -35,10 +31,6 @@ public strictfp class ConcurrentFloatMask implements ConcurrentMask {
 	}
 
 	public ConcurrentFloatMask init(ConcurrentBinaryMask other, float low, float high) {
-		if (VisualDebugger.ENABLED) {
-			this.floatMask.init(other.getBinaryMask(), low, high);
-			return this;
-		}
 		return Pipeline.add(this, Arrays.asList(this, other), res -> {
 				return this.floatMask.init(((ConcurrentBinaryMask) res.get(1)).getBinaryMask(), low, high);
 			}
@@ -46,60 +38,30 @@ public strictfp class ConcurrentFloatMask implements ConcurrentMask {
 	}
 
 	public ConcurrentFloatMask add(ConcurrentFloatMask other) {
-		if (VisualDebugger.ENABLED) {
-			this.floatMask.add(other.getFloatMask());
-			return this;
-		}
 		return Pipeline.add(this, Arrays.asList(this, other), res ->
 				this.floatMask.add(((ConcurrentFloatMask)res.get(1)).getFloatMask())
 		);
 	}
 
-	public ConcurrentFloatMask max(ConcurrentBinaryMask other) {
-		if (VisualDebugger.ENABLED) {
-			throw new UnsupportedOperationException();
-		}
-		return Pipeline.add(this, Arrays.asList(this, other), res ->
-				// Probably a bug, res should be BinaryMask
-				this.floatMask.max(((ConcurrentFloatMask)res.get(1)).getFloatMask())
-		);
-	}
-
 	public ConcurrentFloatMask maskToMoutains(float firstSlope, float slope, ConcurrentBinaryMask other) {
-		if (VisualDebugger.ENABLED) {
-			this.floatMask.maskToMoutains(firstSlope, slope, other.getBinaryMask());
-			return this;
-		}
 		return Pipeline.add(this, Arrays.asList(this, other), res ->
 				this.floatMask.maskToMoutains(firstSlope, slope, ((ConcurrentBinaryMask)res.get(1)).getBinaryMask())
 		);
 	}
 
 	public ConcurrentFloatMask maskToHeightmap(float slope, float underWaterSlope, int maxRepeat, ConcurrentBinaryMask other) {
-		if (VisualDebugger.ENABLED) {
-			this.floatMask.maskToHeightmap(slope, underWaterSlope, maxRepeat, other.getBinaryMask());
-			return this;
-		}
 		return Pipeline.add(this, Arrays.asList(this, other), res ->
 				this.floatMask.maskToHeightmap(slope, underWaterSlope, maxRepeat, ((ConcurrentBinaryMask)res.get(1)).getBinaryMask())
 		);
 	}
 
 	public ConcurrentFloatMask smooth(float radius) {
-		if (VisualDebugger.ENABLED) {
-			this.floatMask.smooth(radius);
-			return this;
-		}
 		return Pipeline.add(this, Arrays.asList(this), res ->
 				this.floatMask.smooth(radius)
 		);
 	}
 
 	public ConcurrentFloatMask smooth(float radius, ConcurrentBinaryMask limiter) {
-		if (VisualDebugger.ENABLED) {
-			this.floatMask.smooth(radius, limiter.getBinaryMask());
-			return this;
-		}
 		return Pipeline.add(this, Arrays.asList(this, limiter), res ->
 				this.floatMask.smooth(radius, ((ConcurrentBinaryMask) res.get(1)).getBinaryMask())
 		);
@@ -126,5 +88,9 @@ public strictfp class ConcurrentFloatMask implements ConcurrentMask {
 	
 	public void startVisualDebugger() {
 		VisualDebugger.whitelistMask(this.floatMask);
+	}
+	
+	public void startVisualDebugger(String maskName) {
+		VisualDebugger.whitelistMask(this.floatMask, maskName);
 	}
 }

--- a/src/java/map/ConcurrentFloatMask.java
+++ b/src/java/map/ConcurrentFloatMask.java
@@ -123,4 +123,8 @@ public strictfp class ConcurrentFloatMask implements ConcurrentMask {
 	public String getName() {
 		return name;
 	}
+	
+	public void startVisualDebugger() {
+		VisualDebugger.whitelistMask(this.floatMask);
+	}
 }

--- a/src/java/map/ConcurrentFloatMask.java
+++ b/src/java/map/ConcurrentFloatMask.java
@@ -15,6 +15,10 @@ public strictfp class ConcurrentFloatMask implements ConcurrentMask {
 	public ConcurrentFloatMask(int size, long seed, String name) {
 		this.floatMask = new FloatMask(size, seed);
 		this.name = name;
+		
+		Pipeline.add(this, Arrays.asList(), res ->
+				Arrays.asList()
+		);
 	}
 
 	public ConcurrentFloatMask(ConcurrentFloatMask mask, long seed, String name) {

--- a/src/java/map/ConcurrentMask.java
+++ b/src/java/map/ConcurrentMask.java
@@ -2,7 +2,7 @@ package map;
 
 import java.nio.file.Path;
 
-public strictfp interface ConcurrentMask {
+public strictfp interface ConcurrentMask extends Mask {
 
 	public ConcurrentMask mockClone();
 	public String getName();

--- a/src/java/map/FloatMask.java
+++ b/src/java/map/FloatMask.java
@@ -10,7 +10,9 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Random;
 
-public strictfp class FloatMask {
+import generator.VisualDebugger;
+
+public strictfp class FloatMask implements Mask {
 	private float[][] mask;
 	private final Random random;
 	private final Symmetry symmetry = Symmetry.POINT;
@@ -62,6 +64,7 @@ public strictfp class FloatMask {
 				}
 			}
 		}
+		VisualDebugger.visualizeMask(this);
 		return this;
 	}
 
@@ -71,6 +74,7 @@ public strictfp class FloatMask {
 				mask[x][y] += other.get(x, y);
 			}
 		}
+		VisualDebugger.visualizeMask(this);
 		return this;
 	}
 	
@@ -80,6 +84,7 @@ public strictfp class FloatMask {
 				mask[x][y] = StrictMath.max(mask[x][y],other.get(x, y));
 			}
 		}
+		VisualDebugger.visualizeMask(this);
 		return this;
 	}
 
@@ -94,6 +99,7 @@ public strictfp class FloatMask {
 			otherCopy.acid(0.5f);
 		}
 		applySymmetry();
+		VisualDebugger.visualizeMask(this);
 		return this;
 	}
 	
@@ -111,6 +117,7 @@ public strictfp class FloatMask {
 			add(layer.init(otherCopy, 0 , -underWaterSlope));
 			otherCopy.acid(0.5f);
 		}
+		VisualDebugger.visualizeMask(this);
 		return this;
 	}
 
@@ -133,6 +140,7 @@ public strictfp class FloatMask {
 			}
 		}
 		mask = maskCopy;
+		VisualDebugger.visualizeMask(this);
 		return this;
 	}
 
@@ -174,6 +182,7 @@ public strictfp class FloatMask {
 			}
 		}
 		mask = maskCopy;
+		VisualDebugger.visualizeMask(this);
 		return this;
 	}
 
@@ -215,5 +224,10 @@ public strictfp class FloatMask {
 		}
 
 		out.close();
+	}
+	
+	@Override
+	public void startVisualDebugger() {
+		VisualDebugger.whitelistMask(this);
 	}
 }

--- a/src/java/map/FloatMask.java
+++ b/src/java/map/FloatMask.java
@@ -230,4 +230,8 @@ public strictfp class FloatMask implements Mask {
 	public void startVisualDebugger() {
 		VisualDebugger.whitelistMask(this);
 	}
+	
+	public void startVisualDebugger(String maskName) {
+		VisualDebugger.whitelistMask(this, maskName);
+	}
 }

--- a/src/java/map/Mask.java
+++ b/src/java/map/Mask.java
@@ -1,0 +1,5 @@
+package map;
+
+public interface Mask {
+	public void startVisualDebugger();
+}

--- a/src/java/util/Pipeline.java
+++ b/src/java/util/Pipeline.java
@@ -1,6 +1,7 @@
 package util;
 
 import generator.MapGenerator;
+import generator.VisualDebugger;
 import map.ConcurrentBinaryMask;
 import map.ConcurrentFloatMask;
 import map.ConcurrentMask;
@@ -18,12 +19,20 @@ public strictfp class Pipeline {
 	private static List<Entry> pipeline = new ArrayList<>();
 
     public static ConcurrentBinaryMask add(ConcurrentBinaryMask executingMask, List<ConcurrentMask> dep, Function<List<ConcurrentMask>, ?> function) {
-        addInternal(executingMask, dep, function);
+    	if (VisualDebugger.ENABLED) {
+			function.apply(dep);
+			return executingMask;
+		}
+    	addInternal(executingMask, dep, function);
         return executingMask;
     }
 
     public static ConcurrentFloatMask add(ConcurrentFloatMask executingMask, List<ConcurrentMask> dep, Function<List<ConcurrentMask>,?> function) {
-        addInternal(executingMask, dep, function);
+    	if (VisualDebugger.ENABLED) {
+			function.apply(dep);
+			return executingMask;
+		}
+    	addInternal(executingMask, dep, function);
         return executingMask;
     }
 


### PR DESCRIPTION
Can somebody please test this a bit or something.
Usage:
Set `VisualDebugger.ENABLED` to true, then to draw mask operations for all masks `VisualDebugger.startRecordAll()` or to only draw operations of specific masks `mask.startVisualDebugger()`. Use debugger to step through operations to see each step clearly or run in normal mode for realtime visualization.

When `VisualDebugger.ENABLED` is true, concurrent masks are reverted to be synchronous to make proper stepping through easy, this reduces performance obviously.
