### PR TITLE
Substantially changed how all texture layers/masks are used

### DIFF
--- a/src/java/generator/MapGenerator.java
+++ b/src/java/generator/MapGenerator.java
@@ -766,7 +766,7 @@ public strictfp class MapGenerator {
 
     private void setupTexturePipeline() {
         ConcurrentBinaryMask flat = new ConcurrentBinaryMask(slope, .05f, random.nextLong(), "flat").invert();
-        ConcurrentBinaryMask inland = new ConcurrentBinaryMask(land, random.nextLong(), "inland").invert();
+        ConcurrentBinaryMask inland = new ConcurrentBinaryMask(land, random.nextLong(), "inland");
         ConcurrentBinaryMask highGround = new ConcurrentBinaryMask(heightmapBase, waterHeight+3f, random.nextLong(), "highGround");
         ConcurrentBinaryMask aboveBeach = new ConcurrentBinaryMask(heightmapBase, waterHeight+1.5f, random.nextLong(), "aboveBeach");
         ConcurrentBinaryMask aboveBeachEdge = new ConcurrentBinaryMask(heightmapBase, waterHeight+3f, random.nextLong(), "aboveBeachEdge");
@@ -792,11 +792,11 @@ public strictfp class MapGenerator {
         rockTexture = new ConcurrentFloatMask(mapSize / 2, random.nextLong(), symmetryHierarchy, "rockTexture");
         accentRockTexture = new ConcurrentFloatMask(mapSize / 2, random.nextLong(), symmetryHierarchy, "accentRockTexture");
 
-        inland.erode(1f, symmetryHierarchy.getSpawnSymmetry()).erode(1f, symmetryHierarchy.getSpawnSymmetry());
+        inland.deflate(2);
         flatAboveCoast.intersect(flat);
         higherFlatAboveCoast.intersect(flat);
-        lowWaterBeach.invert().grow(1f).grow(1f).grow(1f).grow(1f).grow(1f).grow(1f).minus(aboveBeach);
-        waterBeach.invert().minus(flatAboveCoast).minus(inland).grow(1f).combine(lowWaterBeach).smooth(5, 0.5f).minus(aboveBeach).minus(higherFlatAboveCoast).smooth(2).smooth(1);
+        lowWaterBeach.invert().inflate(6).minus(aboveBeach);
+        waterBeach.invert().minus(flatAboveCoast).minus(inland).inflate(1).combine(lowWaterBeach).smooth(5, 0.5f).minus(aboveBeach).minus(higherFlatAboveCoast).smooth(2).smooth(1);
         accentGround.minus(highGround).acid(.1f, 0).erode(.4f, symmetryHierarchy.getSpawnSymmetry()).smooth(3, .75f);
         accentPlateau.acid(.05f, 0).erode(.85f, symmetryHierarchy.getSpawnSymmetry()).smooth(2, .75f).acid(.45f, 0);
         slopes.intersect(land).flipValues(.95f).erode(.5f, symmetryHierarchy.getSpawnSymmetry()).acid(.3f, 0).erode(.2f, symmetryHierarchy.getSpawnSymmetry());
@@ -804,7 +804,10 @@ public strictfp class MapGenerator {
         rockBase.acid(.3f, 0).erode(.2f, symmetryHierarchy.getSpawnSymmetry());
         accentRock.acid(.2f, 0).erode(.3f, symmetryHierarchy.getSpawnSymmetry()).acid(.2f, 0).smooth(2, .5f).intersect(rock);
 
-        waterBeachTexture.init(waterBeach,0,1).subtract(rock, 1f).subtract(aboveBeachEdge,1f).clampMin(0).smooth(2).add(waterBeach, 1f).subtract(rock, 1f).subtract(aboveBeachEdge,.9f).clampMin(0).smooth(2).subtract(rock, 1f).subtract(aboveBeachEdge,.8f).clampMin(0).add(waterBeach, .65f).smooth(2).subtract(rock, 1f).subtract(aboveBeachEdge,0.7f).clampMin(0).add(waterBeach, .5f).smooth(2).smooth(2).subtract(rock, 1f).clampMin(0).smooth(2).smooth(2).subtract(rock, 1f).clampMin(0).smooth(2).smooth(1).smooth(1).clampMax(1f);
+        waterBeachTexture.init(waterBeach,0,1).subtract(rock, 1f).subtract(aboveBeachEdge,1f).clampMin(0).smooth(2, rock.copy().invert()).add(waterBeach, 1f).subtract(rock, 1f);
+        waterBeachTexture.subtract(aboveBeachEdge,.9f).clampMin(0).smooth(2, rock.copy().invert()).subtract(rock, 1f).subtract(aboveBeachEdge,.8f).clampMin(0).add(waterBeach, .65f).smooth(2, rock.copy().invert());
+        waterBeachTexture.subtract(rock, 1f).subtract(aboveBeachEdge,0.7f).clampMin(0).add(waterBeach, .5f).smooth(2, rock.copy().invert()).smooth(2, rock.copy().invert()).subtract(rock, 1f).clampMin(0).smooth(2, rock.copy().invert());
+        waterBeachTexture.smooth(2, rock.copy().invert()).subtract(rock, 1f).clampMin(0).smooth(2, rock.copy().invert()).smooth(1, rock.copy().invert()).smooth(1, rock.copy().invert()).clampMax(1f);
         accentGroundTexture.init(accentGround, 0, 1).smooth(8).add(accentGround, .65f).smooth(4).add(accentGround, .5f).smooth(1).clampMax(1f);
         accentPlateauTexture.init(accentPlateau, 0, 1).smooth(8).add(accentPlateau, .65f).smooth(4).add(accentPlateau, .5f).smooth(1).clampMax(1f);
         slopesTexture.init(slopes, 0, 1).smooth(8).add(slopes, .65f).smooth(4).add(slopes, .5f).smooth(1).clampMax(1f);

--- a/src/java/map/ConcurrentFloatMask.java
+++ b/src/java/map/ConcurrentFloatMask.java
@@ -1,5 +1,6 @@
 package map;
 
+import generator.VisualDebugger;
 import lombok.Getter;
 import util.Pipeline;
 import util.Util;
@@ -55,6 +56,18 @@ public strictfp class ConcurrentFloatMask extends ConcurrentMask {
         return Pipeline.add(this, Arrays.asList(this, other), res ->
                 this.floatMask.add(((ConcurrentBinaryMask) res.get(1)).getBinaryMask(), value)
         );
+    }
+
+    public ConcurrentFloatMask subtract(ConcurrentFloatMask other) {
+        return Pipeline.add(this, Arrays.asList(this, other), res ->
+                this.floatMask.add(((ConcurrentFloatMask) res.get(1)).getFloatMask())
+        ).multiply(-1);
+    }
+
+    public ConcurrentFloatMask subtract(ConcurrentBinaryMask other, float value) {
+        return Pipeline.add(this, Arrays.asList(this, other), res ->
+                this.floatMask.add(((ConcurrentBinaryMask) res.get(1)).getBinaryMask(), value)
+        ).multiply(-1);
     }
 
     public ConcurrentFloatMask multiply(float value) {

--- a/src/java/map/ConcurrentFloatMask.java
+++ b/src/java/map/ConcurrentFloatMask.java
@@ -1,6 +1,5 @@
 package map;
 
-import generator.VisualDebugger;
 import lombok.Getter;
 import util.Pipeline;
 import util.Util;
@@ -60,14 +59,14 @@ public strictfp class ConcurrentFloatMask extends ConcurrentMask {
 
     public ConcurrentFloatMask subtract(ConcurrentFloatMask other) {
         return Pipeline.add(this, Arrays.asList(this, other), res ->
-                this.floatMask.add(((ConcurrentFloatMask) res.get(1)).getFloatMask())
-        ).multiply(-1);
+                this.floatMask.subtract(((ConcurrentFloatMask) res.get(1)).getFloatMask())
+        );
     }
 
     public ConcurrentFloatMask subtract(ConcurrentBinaryMask other, float value) {
         return Pipeline.add(this, Arrays.asList(this, other), res ->
-                this.floatMask.add(((ConcurrentBinaryMask) res.get(1)).getBinaryMask(), value)
-        ).multiply(-1);
+                this.floatMask.subtract(((ConcurrentBinaryMask) res.get(1)).getBinaryMask(), value)
+        );
     }
 
     public ConcurrentFloatMask multiply(float value) {

--- a/src/java/populator/MapPopulator.java
+++ b/src/java/populator/MapPopulator.java
@@ -260,15 +260,22 @@ public strictfp class MapPopulator {
             map.getDecals().clear();
 
             BinaryMask flat = new BinaryMask(slope, .05f, random.nextLong()).invert();
-            BinaryMask ground = new BinaryMask(land, random.nextLong());
+            BinaryMask inland = new BinaryMask(land, random.nextLong());
+            BinaryMask highGround = new BinaryMask(heightmapBase, waterHeight+3f, random.nextLong());
+            BinaryMask aboveBeach = new BinaryMask(heightmapBase, waterHeight+1.5f, random.nextLong());
+            BinaryMask aboveBeachEdge = new BinaryMask(heightmapBase, waterHeight+3f, random.nextLong());
+            BinaryMask flatAboveCoast = new BinaryMask(heightmapBase, waterHeight+0.29f, random.nextLong());
+            BinaryMask higherFlatAboveCoast = new BinaryMask(heightmapBase, waterHeight+1.2f, random.nextLong());
+            BinaryMask lowWaterBeach = new BinaryMask(heightmapBase, waterHeight, random.nextLong());
+            BinaryMask waterBeach = new BinaryMask(heightmapBase, waterHeight+1f, random.nextLong());
             BinaryMask accentGround = new BinaryMask(land, random.nextLong());
             BinaryMask accentPlateau = new BinaryMask(plateaus, random.nextLong());
             BinaryMask slopes = new BinaryMask(slope, .1f, random.nextLong());
             BinaryMask accentSlopes = new BinaryMask(slope, .75f, random.nextLong()).invert();
-            BinaryMask rockBase = new BinaryMask(slope, .5f, random.nextLong());
+            BinaryMask rockBase = new BinaryMask(slope, .55f, random.nextLong());
             BinaryMask rock = new BinaryMask(slope, 1.25f, random.nextLong());
             BinaryMask accentRock = new BinaryMask(slope, 1.25f, random.nextLong());
-            FloatMask groundTexture = new FloatMask(map.getSize() / 2, random.nextLong(), symmetryHierarchy);
+            FloatMask waterBeachTexture = new FloatMask(map.getSize() / 2, random.nextLong(), symmetryHierarchy);
             FloatMask accentGroundTexture = new FloatMask(map.getSize() / 2, random.nextLong(), symmetryHierarchy);
             FloatMask accentPlateauTexture = new FloatMask(map.getSize() / 2, random.nextLong(), symmetryHierarchy);
             FloatMask slopesTexture = new FloatMask(map.getSize() / 2, random.nextLong(), symmetryHierarchy);
@@ -277,26 +284,33 @@ public strictfp class MapPopulator {
             FloatMask rockTexture = new FloatMask(map.getSize() / 2, random.nextLong(), symmetryHierarchy);
             FloatMask accentRockTexture = new FloatMask(map.getSize() / 2, random.nextLong(), symmetryHierarchy);
 
-            ground.shrink(map.getSize() / 4).erode(.75f, symmetryHierarchy.getSpawnSymmetry(), 8).grow(.5f, symmetryHierarchy.getSpawnSymmetry(), 8);
-            ground.combine(plateaus).intersect(land).smooth(2, .25f).filterShapes(32);
-            accentGround.minus(plateaus).acid(.1f, 0).erode(.5f, symmetryHierarchy.getSpawnSymmetry()).smooth(8, .75f);
-            accentPlateau.acid(.1f, 0).erode(.5f, symmetryHierarchy.getSpawnSymmetry()).smooth(8, .75f);
-            slopes.intersect(land).flipValues(.95f).erode(.5f, symmetryHierarchy.getSpawnSymmetry());
-            accentSlopes.minus(flat).intersect(land).acid(.1f, 0).erode(.5f, symmetryHierarchy.getSpawnSymmetry()).smooth(8, .75f);
-            rockBase.intersect(land).erode(.5f, symmetryHierarchy.getSpawnSymmetry(), 4).grow(.5f, symmetryHierarchy.getSpawnSymmetry(), 4).smooth(2);
-            accentRock.acid(.1f, 0).erode(.5f, symmetryHierarchy.getSpawnSymmetry()).smooth(8, .5f).intersect(rock);
+            inland.erode(1f, symmetryHierarchy.getSpawnSymmetry()).erode(1f, symmetryHierarchy.getSpawnSymmetry());
+            flatAboveCoast.intersect(flat);
+            higherFlatAboveCoast.intersect(flat);
+            lowWaterBeach.invert().grow(1f).grow(1f).grow(1f).grow(1f).grow(1f).grow(1f).minus(aboveBeach);
+            if (waterPresent) {
+                waterBeach.invert().minus(flatAboveCoast).minus(inland).grow(1f).combine(lowWaterBeach).smooth(5, 0.5f).minus(aboveBeach).minus(higherFlatAboveCoast).smooth(2).smooth(1);
+            } else {
+                waterBeach.clear();
+            }
+            accentGround.minus(highGround).acid(.05f, 0).erode(.85f, symmetryHierarchy.getSpawnSymmetry()).smooth(2, .75f).acid(.45f, 0);
+            accentPlateau.acid(.05f, 0).erode(.85f, symmetryHierarchy.getSpawnSymmetry()).smooth(2, .75f).acid(.45f, 0);
+            slopes.intersect(land).flipValues(.95f).erode(.5f, symmetryHierarchy.getSpawnSymmetry()).acid(.3f, 0).erode(.2f, symmetryHierarchy.getSpawnSymmetry());
+            accentSlopes.minus(flat).intersect(land).acid(.1f, 0).erode(.5f, symmetryHierarchy.getSpawnSymmetry()).smooth(4, .75f).acid(.55f, 0);
+            rockBase.acid(.3f, 0).erode(.2f, symmetryHierarchy.getSpawnSymmetry());
+            accentRock.acid(.2f, 0).erode(.3f, symmetryHierarchy.getSpawnSymmetry()).acid(.2f, 0).smooth(2, .5f).intersect(rock);
 
-            groundTexture.init(ground, 0, 1).smooth(4).clampMax(1f);
-            accentGroundTexture.init(accentGround, 0, 1).smooth(4).clampMax(1f);
-            accentPlateauTexture.init(accentPlateau, 0, 1).smooth(4).clampMax(1f);
-            slopesTexture.init(slopes, 0, 1).smooth(4).clampMax(1f);
-            accentSlopesTexture.init(accentSlopes, 0, 1).smooth(4).clampMax(1f);
-            rockBaseTexture.init(rockBase, 0, 1).smooth(4).clampMax(1f);
-            rockTexture.init(rock, 0, 1).smooth(8).add(rock, .65f).smooth(4).add(rock, .5f).smooth(1).clampMax(1f);
-            accentRockTexture.init(accentRock, 0, 1).smooth(2).clampMax(1f);
+            waterBeachTexture.init(waterBeach,0,1).subtract(rock, 1f).subtract(aboveBeachEdge,1f).clampMin(0).smooth(2).add(waterBeach, 1f).subtract(rock, 1f).subtract(aboveBeachEdge,.9f).clampMin(0).smooth(2).subtract(rock, 1f).subtract(aboveBeachEdge,.8f).clampMin(0).add(waterBeach, .65f).smooth(2).subtract(rock, 1f).subtract(aboveBeachEdge,0.7f).clampMin(0).add(waterBeach, .5f).smooth(2).smooth(2).subtract(rock, 1f).clampMin(0).smooth(2).smooth(2).subtract(rock, 1f).clampMin(0).smooth(2).smooth(1).smooth(1).clampMax(1f);
+            accentGroundTexture.init(accentGround, 0, 1).smooth(8).add(accentGround, .65f).smooth(4).add(accentGround, .5f).smooth(1).clampMax(1f);
+            accentPlateauTexture.init(accentPlateau, 0, 1).smooth(8).add(accentPlateau, .65f).smooth(4).add(accentPlateau, .5f).smooth(1).clampMax(1f);
+            slopesTexture.init(slopes, 0, 1).smooth(8).add(slopes, .65f).smooth(4).add(slopes, .5f).smooth(1).clampMax(1f);
+            accentSlopesTexture.init(accentSlopes, 0, 1).smooth(8).add(accentSlopes, .65f).smooth(4).add(accentSlopes, .5f).smooth(1).clampMax(1f);
+            rockBaseTexture.init(rockBase, 0, 1).smooth(8).clampMax(0.35f).add(rockBase, .65f).smooth(4).clampMax(0.65f).add(rockBase, .5f).smooth(1).add(rockBase, 1f).clampMax(1f);
+            rockTexture.init(rock, 0, 1).smooth(8).clampMax(0.2f).add(rock, .65f).smooth(4).clampMax(0.3f).add(rock, .5f).smooth(1).add(rock, 1f).clampMax(1f);
+            accentRockTexture.init(accentRock, 0, 1).subtract(waterBeachTexture).clampMin(0).smooth(8).add(accentRock, .65f).smooth(4).add(accentRock, .5f).smooth(1).clampMax(1f);
 
-            map.setTextureMasksLow(groundTexture, accentGroundTexture, accentPlateauTexture, slopesTexture);
-            map.setTextureMasksHigh(accentSlopesTexture, rockBaseTexture, rockTexture, accentRockTexture);
+            map.setTextureMasksLow(accentGroundTexture, accentPlateauTexture, slopesTexture, accentSlopesTexture);
+            map.setTextureMasksHigh(rockBaseTexture, waterBeachTexture, rockTexture, accentRockTexture);
         }
 
         if (populateProps) {

--- a/src/java/populator/MapPopulator.java
+++ b/src/java/populator/MapPopulator.java
@@ -284,12 +284,12 @@ public strictfp class MapPopulator {
             FloatMask rockTexture = new FloatMask(map.getSize() / 2, random.nextLong(), symmetryHierarchy);
             FloatMask accentRockTexture = new FloatMask(map.getSize() / 2, random.nextLong(), symmetryHierarchy);
 
-            inland.erode(1f, symmetryHierarchy.getSpawnSymmetry()).erode(1f, symmetryHierarchy.getSpawnSymmetry());
+            inland.deflate(2);
             flatAboveCoast.intersect(flat);
             higherFlatAboveCoast.intersect(flat);
-            lowWaterBeach.invert().grow(1f).grow(1f).grow(1f).grow(1f).grow(1f).grow(1f).minus(aboveBeach);
+            lowWaterBeach.invert().inflate(6).minus(aboveBeach);
             if (waterPresent) {
-                waterBeach.invert().minus(flatAboveCoast).minus(inland).grow(1f).combine(lowWaterBeach).smooth(5, 0.5f).minus(aboveBeach).minus(higherFlatAboveCoast).smooth(2).smooth(1);
+                waterBeach.invert().minus(flatAboveCoast).minus(inland).inflate(1).combine(lowWaterBeach).smooth(5, 0.5f).minus(aboveBeach).minus(higherFlatAboveCoast).smooth(2).smooth(1);
             } else {
                 waterBeach.clear();
             }
@@ -300,7 +300,10 @@ public strictfp class MapPopulator {
             rockBase.acid(.3f, 0).erode(.2f, symmetryHierarchy.getSpawnSymmetry());
             accentRock.acid(.2f, 0).erode(.3f, symmetryHierarchy.getSpawnSymmetry()).acid(.2f, 0).smooth(2, .5f).intersect(rock);
 
-            waterBeachTexture.init(waterBeach,0,1).subtract(rock, 1f).subtract(aboveBeachEdge,1f).clampMin(0).smooth(2).add(waterBeach, 1f).subtract(rock, 1f).subtract(aboveBeachEdge,.9f).clampMin(0).smooth(2).subtract(rock, 1f).subtract(aboveBeachEdge,.8f).clampMin(0).add(waterBeach, .65f).smooth(2).subtract(rock, 1f).subtract(aboveBeachEdge,0.7f).clampMin(0).add(waterBeach, .5f).smooth(2).smooth(2).subtract(rock, 1f).clampMin(0).smooth(2).smooth(2).subtract(rock, 1f).clampMin(0).smooth(2).smooth(1).smooth(1).clampMax(1f);
+            waterBeachTexture.init(waterBeach,0,1).subtract(rock, 1f).subtract(aboveBeachEdge,1f).clampMin(0).smooth(2, rock.copy().invert()).add(waterBeach, 1f).subtract(rock, 1f);
+            waterBeachTexture.subtract(aboveBeachEdge,.9f).clampMin(0).smooth(2, rock.copy().invert()).subtract(rock, 1f).subtract(aboveBeachEdge,.8f).clampMin(0).add(waterBeach, .65f).smooth(2, rock.copy().invert());
+            waterBeachTexture.subtract(rock, 1f).subtract(aboveBeachEdge,0.7f).clampMin(0).add(waterBeach, .5f).smooth(2, rock.copy().invert()).smooth(2, rock.copy().invert()).subtract(rock, 1f).clampMin(0).smooth(2, rock.copy().invert());
+            waterBeachTexture.smooth(2, rock.copy().invert()).subtract(rock, 1f).clampMin(0).smooth(2, rock.copy().invert()).smooth(1, rock.copy().invert()).smooth(1, rock.copy().invert()).clampMax(1f);
             accentGroundTexture.init(accentGround, 0, 1).smooth(8).add(accentGround, .65f).smooth(4).add(accentGround, .5f).smooth(1).clampMax(1f);
             accentPlateauTexture.init(accentPlateau, 0, 1).smooth(8).add(accentPlateau, .65f).smooth(4).add(accentPlateau, .5f).smooth(1).clampMax(1f);
             slopesTexture.init(slopes, 0, 1).smooth(8).add(slopes, .65f).smooth(4).add(slopes, .5f).smooth(1).clampMax(1f);

--- a/src/resources/custom_biome/Cadmium/materials.json
+++ b/src/resources/custom_biome/Cadmium/materials.json
@@ -1,12 +1,12 @@
 {
   "name": "Cadmium",
   "texturePaths": [
-    "/env/Evergreen/layers/macrotexture000_albedo.dds",
     "/env/Evergreen2/Layers/EvGrass009_albedo.dds",
     "/env/Tropical/Layers/TrRock002_albedo.dds",
     "/env/Tropical/Layers/Trop_Grass_albedo.dds",
     "/env/Tropical/Layers/Trop_Rock_albedo.DDS",
     "/env/Tropical/Layers/Trop_Dirt_albedo.DDS",
+    "/env/Evergreen/layers/macrotexture000_albedo.dds",
     "/env/Tropical/Layers/TrRock003_albedo.dds",
     "/env/Tropical/Layers/TrRock005_albedo.dds",
     "/env/Tropical/Layers/Tr_GrassHills_albedo.dds",
@@ -14,44 +14,40 @@
   ],
   "textureScales": [
     10.0,
-    10.0,
     2.0,
     8.0,
     8.0,
     16.0,
+    10.0,
     4.0,
     16.0,
     16.0,
     128.0
   ],
   "normalPaths": [
-    "/env/Evergreen/layers/SandLight_normals.dds",
     "/env/Tropical/Layers/TrTrans002_Normal.dds",
     "/env/Tropical/Layers/Trop_Rock_Normal.DDS",
     "/env/Tropical/Layers/TrRock006_normal.dds",
     "/env/Evergreen/layers/RockMed_normals.dds",
     "/env/Tropical/Layers/TrBush_moss_Normal.dds",
+    "/env/Evergreen/layers/SandLight_normals.dds",
     "/env/Tropical/Layers/Trop_Rock_Normal.DDS",
     "/env/Tropical/Layers/TrRock006_normal.dds",
     "/env/Tropical/Layers/Tr_GrassHills_normal.dds"
   ],
   "normalScales": [
-    4.0,
     8.0,
     16.0,
     8.0,
     8.0,
     8.0,
+    4.0,
     16.0,
     16.0,
     16.0
   ],
   "previewColors": [
-    {
-      "value": -13289948,
-      "falpha": 0.0
-    },
-    {
+   {
       "value": -14406639,
       "falpha": 0.0
     },
@@ -69,6 +65,10 @@
     },
     {
       "value": -14081264,
+      "falpha": 0.0
+    },
+    {
+      "value": -13289948,
       "falpha": 0.0
     },
     {

--- a/src/resources/custom_biome/Desert/materials.json
+++ b/src/resources/custom_biome/Desert/materials.json
@@ -1,56 +1,52 @@
 {
   "name": "Desert",
   "texturePaths": [
-    "/env/Desert/Layers/Des_SandMed01_albedo.dds",
     "/env/Desert/Layers/Des_SandDark_albedo.dds",
     "/env/Desert/Layers/Des_SandDark02_albedo.dds",
     "/env/Desert/Layers/Des_SandMed02_albedo.dds",
     "/env/Desert/Layers/Des_SandMed_albedo.dds",
     "/env/Desert/Layers/Des_Gravel_albedo.dds",
+    "/env/Desert/Layers/Des_SandMed01_albedo.dds",
     "/env/Desert/Layers/Des_Rock04_albedo.dds",
     "/env/Desert/Layers/Des_Rock06_albedo.dds",
     "/env/Desert/Layers/Des_Rock_albedo.dds",
     "/env/Evergreen/layers/macrotexture000_albedo.dds"
   ],
   "textureScales": [
-    10.609999656677246,
     4.0,
     8.0,
     8.0,
     8.0,
     16.0,
+    10.609999656677246,
     16.0,
     8.0,
     16.0,
     128.0
   ],
   "normalPaths": [
-    "/env/paradise/layers/sand000_normals.dds",
     "/env/Desert/Layers/Des_SandDark_normal.dds",
     "/env/Desert/Layers/Des_Gravel_normal.dds",
     "/env/Desert/Layers/Des_sandLight_normal.dds",
     "/env/Tundra/Layers/Tund_sandLight_normal.dds",
     "/env/Desert/Layers/Des_Gravel_normal.dds",
+    "/env/paradise/layers/sand000_normals.dds",
     "/env/Desert/Layers/Des_Rock03a_normal.dds",
     "/env/Tundra/Layers/Tund_sandLight_normal.dds",
     "/env/Desert/Layers/Des_Rock01_normal.dds"
   ],
   "normalScales": [
+    4.0,
+    8.0,
+    8.0,
+    8.0,
+    4.0,
     20.0,
-    4.0,
-    8.0,
-    8.0,
-    8.0,
-    4.0,
     4.0,
     4.0,
     4.0
   ],
   "previewColors": [
-    {
-      "value": -6518683,
-      "falpha": 0.0
-    },
     {
       "value": -7376820,
       "falpha": 0.0
@@ -69,6 +65,10 @@
     },
     {
       "value": -10069694,
+      "falpha": 0.0
+    },
+    {
+      "value": -6518683,
       "falpha": 0.0
     },
     {

--- a/src/resources/custom_biome/Frithen/materials.json
+++ b/src/resources/custom_biome/Frithen/materials.json
@@ -1,11 +1,11 @@
 {
   "name": "Frithen",
   "texturePaths": [
-    "/env/Tundra/Layers/Tund_melt001_albedo.dds",
     "/env/Tundra/Layers/Tund_Rock03_albedo.DDS",
     "/env/Tundra/Layers/Tund_iceRock_albedo.dds",
     "/env/Tundra/Layers/Tund_Ice001_albedo.DDS",
     "/env/Tundra/Layers/Tund_iceRock_albedo.dds",
+    "/env/Tundra/Layers/Tund_melt001_albedo.dds",
     "/env/Tundra/Layers/Tund_melt001_albedo.dds",
     "/env/Tundra/Layers/Tund_Rock03_albedo.DDS",
     "/env/Tundra/Layers/Tund_melt001_albedo.dds",
@@ -13,12 +13,12 @@
     "/env/Evergreen/layers/macrotexture000_albedo.dds"
   ],
   "textureScales": [
-    1.0,
     2.0,
     0.0,
     16.0,
     6.0,
     8.0,
+    1.0,
     16.0,
     16.0,
     16.0,
@@ -26,11 +26,11 @@
   ],
   "normalPaths": [
     "/env/Tundra/Layers/Tund_Rock_normal.dds",
-    "/env/Tundra/Layers/Tund_Rock_normal.dds",
     "/env/Tundra/Layers/Tund_Ice003_normal.dds",
     "/env/Crystalline/layers/Cr_02_01_normal.dds",
     "/env/Crystalline/layers/Cr_Rock002b_normal.dds",
     "/env/Evergreen2/Layers/EG_Rock004_normal.dds",
+    "/env/Tundra/Layers/Tund_Rock_normal.dds",
     "/env/Tundra/Layers/Tund_Rock_normal.dds",
     "/env/Tundra/Layers/Tund_sandLight_normal.dds",
     "/env/Tundra/Layers/Tund_sandLight_normal.dds"
@@ -48,10 +48,6 @@
   ],
   "previewColors": [
     {
-      "value": -11709347,
-      "falpha": 0.0
-    },
-    {
       "value": -10065039,
       "falpha": 0.0
     },
@@ -65,6 +61,10 @@
     },
     {
       "value": -7102299,
+      "falpha": 0.0
+    },
+    {
+      "value": -11709347,
       "falpha": 0.0
     },
     {

--- a/src/resources/custom_biome/Loki/materials.json
+++ b/src/resources/custom_biome/Loki/materials.json
@@ -1,12 +1,12 @@
 {
   "name": "Loki",
   "texturePaths": [
-    "/env/Evergreen2/Layers/EV_Reef_Coral_albedo.dds",
     "/env/Evergreen2/Layers/EvTrans03_albedo.dds",
     "/env/Evergreen2/Layers/EvGrass010a_albedo.dds",
     "/env/Evergreen2/Layers/EvGrass003_albedo.dds",
     "/env/Evergreen2/Layers/EG_Gravel2_albedo.dds",
     "/env/Evergreen/layers/SandLight002_albedo.dds",
+    "/env/Evergreen2/Layers/EV_Reef_Coral_albedo.dds",
     "/env/Evergreen2/Layers/EvRock004_albedo.dds",
     "/env/Evergreen2/Layers/EvRock004_albedo.dds",
     "/env/Evergreen2/Layers/EvRock006_albedo.dds",
@@ -14,43 +14,39 @@
   ],
   "textureScales": [
     2.0,
-    2.0,
     4.0,
     12.0,
     4.0,
     4.0,
+    2.0,
     8.0,
     8.0,
     32.0,
     77.5
   ],
   "normalPaths": [
-    "/env/Evergreen2/Layers/EvTrans01_normals.dds",
     "/env/Swamp/layers/Sw_Grass_03_normals.dds",
     "/env/Evergreen/layers/grass001_normals.dds",
     "/env/Evergreen/layers/grass000_normals.dds",
     "/env/Evergreen2/Layers/EvRock006_normal.dds",
     "/env/Evergreen/layers/SandLight_normals.dds",
+    "/env/Evergreen2/Layers/EvTrans01_normals.dds",
     "/env/Tundra/Layers/Tund_sandLight_normal.dds",
     "/env/Tundra/Layers/Tund_sandLight_normal.dds",
     "/env/Tundra/Layers/Tund_sandLight_normal.dds"
   ],
   "normalScales": [
-    8.0,
     0.0,
     8.0,
     10.0,
     8.0,
     4.0,
+    8.0,
     4.0,
     4.0,
     4.0
   ],
   "previewColors": [
-    {
-      "value": -11774650,
-      "falpha": 0.0
-    },
     {
       "value": -12826087,
       "falpha": 0.0
@@ -69,6 +65,10 @@
     },
     {
       "value": -8094093,
+      "falpha": 0.0
+    },
+    {
+      "value": -11774650,
       "falpha": 0.0
     },
     {

--- a/src/resources/custom_biome/Mars/materials.json
+++ b/src/resources/custom_biome/Mars/materials.json
@@ -1,56 +1,52 @@
 {
   "name": "Mars",
   "texturePaths": [
-    "/env/Red Barrens/Layers/RB_Cracked_albedo.DDS",
     "/env/Desert/Layers/Des_Gravel_albedo.dds",
     "/env/Desert/Layers/Des_Rock_albedo.dds",
     "/env/Desert/Layers/Des_SandDark_albedo.dds",
     "/env/Desert/Layers/Des_SandDark02_albedo.dds",
     "/env/Desert/Layers/Des_Rock06_albedo.dds",
+    "/env/Red Barrens/Layers/RB_Cracked_albedo.DDS",
     "/env/Red Barrens/Layers/RB_RedMud_albedo.dds",
     "/env/Red Barrens/Layers/RB_Cracked_albedo.DDS",
     "/env/Red Barrens/Layers/RB_Sandwet01_albedo.dds",
     "/env/Evergreen/layers/macrotexture000_albedo.dds"
   ],
   "textureScales": [
-    7.0,
     1.0,
     0.0,
     20.0,
     10.0,
     10.0,
+    7.0,
     32.0,
     32.0,
     32.0,
     128.0
   ],
   "normalPaths": [
-    "/env/Red Barrens/Layers/RB_Cracked02_normal.DDS",
     "/env/Desert/Layers/Des_Gravel_normal.dds",
     "/env/Desert/Layers/Des_sandLight_normal.dds",
     "/env/Red Barrens/Layers/RB_Rock06_normal.dds",
     "/env/Red Barrens/Layers/RB_Rock06_normal.dds",
     "/env/Evergreen2/Layers/Eg_Gravel2_normal.dds",
+    "/env/Red Barrens/Layers/RB_Cracked02_normal.DDS",
     "/env/Desert/Layers/Des_Rock02_normal.dds",
     "/env/Red Barrens/Layers/RB_Sand_normal.dds",
     "/env/Red Barrens/Layers/RB_Cracked02_normal.DDS"
   ],
   "normalScales": [
-    7.0,
     5.0,
     10.0,
     16.0,
     16.0,
     10.0,
+    7.0,
     4.0,
     7.0,
     7.0
   ],
   "previewColors": [
-    {
-      "value": -11722475,
-      "falpha": 0.0
-    },
     {
       "value": -10069694,
       "falpha": 0.0
@@ -69,6 +65,10 @@
     },
     {
       "value": -11845328,
+      "falpha": 0.0
+    },
+    {
+      "value": -11722475,
       "falpha": 0.0
     },
     {

--- a/src/resources/custom_biome/Moonlight/materials.json
+++ b/src/resources/custom_biome/Moonlight/materials.json
@@ -1,24 +1,24 @@
 {
   "name": "Moonlight",
   "texturePaths": [
-    "/env/Red Barrens/Layers/RB_Cracked_albedo.DDS",
     "/env/Red Barrens/Layers/RB_Cracked02_albedo.DDS",
     "/env/Red Barrens/Layers/RB_Sandwet_albedo.dds",
     "/env/Red Barrens/Layers/RB_Rock04_albedo.dds",
     "/env/Red Barrens/Layers/RB_Cracked02_albedo.DDS",
     "/env/Red Barrens/Layers/RB_Rock03_albedo.dds",
+    "/env/Red Barrens/Layers/RB_Cracked_albedo.DDS",
     "/env/Geothermal/layers/Geo_Dirt_01_albedo.dds",
     "/env/Geothermal/layers/Geo_LavaDk_01_albedo.dds",
     "/env/Geothermal/layers/Geo_Dirt_01_albedo.dds",
     "/env/Evergreen/layers/macrotexture000_albedo.dds"
   ],
   "textureScales": [
-    19.5,
     7.25,
     26.5,
     32.0,
     6.0,
     32.0,
+    19.5,
     16.0,
     32.0,
     32.0,
@@ -26,31 +26,27 @@
   ],
   "normalPaths": [
     "/env/Red Barrens/Layers/RB_Cracked02_normal.DDS",
-    "/env/Red Barrens/Layers/RB_Cracked02_normal.DDS",
     "/env/Red Barrens/Layers/RB_Sandwet_normal.dds",
     "/env/Red Barrens/Layers/RB_Rock09_normal.dds",
     "/env/Red Barrens/Layers/RB_Sand_normal.dds",
     "/env/Red Barrens/Layers/RB_Cracked_normal.DDS",
+    "/env/Red Barrens/Layers/RB_Cracked02_normal.DDS",
     "/env/Red Barrens/Layers/RB_Rock09_normal.dds",
     "/env/Tundra/Layers/Tund_sandLight_normal.dds",
     "/env/Red Barrens/Layers/RB_Rock06_normal.dds"
   ],
   "normalScales": [
-    64.0,
     32.0,
     16.0,
     32.0,
     32.0,
+    64.0,
     64.0,
     32.0,
     4.0,
     4.0
   ],
   "previewColors": [
-    {
-      "value": -11722475,
-      "falpha": 0.0
-    },
     {
       "value": -8707325,
       "falpha": 0.0
@@ -69,6 +65,10 @@
     },
     {
       "value": -9421518,
+      "falpha": 0.0
+    },
+    {
+      "value": -11722475,
       "falpha": 0.0
     },
     {

--- a/src/resources/custom_biome/Prayer/materials.json
+++ b/src/resources/custom_biome/Prayer/materials.json
@@ -1,56 +1,52 @@
 {
   "name": "Prayer",
   "texturePaths": [
-    "/env/paradise/layers/sand000_albedo.dds",
     "/env/Evergreen2/Layers/EvTrans03_albedo.dds",
     "/env/Evergreen2/Layers/EvHostas001_albedo.dds",
     "/env/Evergreen2/Layers/EvTrans02_albedo.dds",
     "/env/Evergreen2/Layers/Eg_Gravel004_albedo.dds",
     "/env/Evergreen2/Layers/EvTrans03_albedo.dds",
+    "/env/paradise/layers/sand000_albedo.dds",
     "/env/Evergreen2/Layers/EvRock006_albedo.dds",
     "/env/Evergreen2/Layers/EvRock006b_albedo.dds",
     "/env/Evergreen2/Layers/EvRock005_albedo.dds",
     "/env/Evergreen/layers/macrotexture000_albedo.dds"
   ],
   "textureScales": [
-    32.0,
     0.0,
     8.0,
     4.0,
     16.0,
     1.0,
+    32.0,
     24.0,
     8.0,
     16.0,
     128.0
   ],
   "normalPaths": [
-    "/env/Evergreen/layers/SandLight002_normals.dds",
     "/env/Evergreen2/Layers/EG_Grass001_normal.dds",
     "/env/Evergreen2/Layers/EG_Grass001_normal.dds",
     "/env/Evergreen2/Layers/EG_Gravel_normal.DDS",
     "/env/Evergreen2/Layers/Eg_Gravel2_normal.dds",
     "/env/Evergreen2/Layers/EvTrans01_normals.dds",
+    "/env/Evergreen/layers/SandLight002_normals.dds",
     "/env/Evergreen2/Layers/EG_Rock003_normal.dds",
     "/env/Evergreen2/Layers/EG_Rock004_normal.dds",
     "/env/Evergreen2/Layers/EG_Rock003_normal.dds"
   ],
   "normalScales": [
-    24.0,
     16.0,
     16.0,
     16.0,
     16.0,
     8.0,
+    24.0,
     6.0,
     16.0,
     8.0
   ],
   "previewColors": [
-    {
-      "value": -8755895,
-      "falpha": 0.0
-    },
     {
       "value": -12826087,
       "falpha": 0.0
@@ -69,6 +65,10 @@
     },
     {
       "value": -12826087,
+      "falpha": 0.0
+    },
+    {
+      "value": -8755895,
       "falpha": 0.0
     },
     {

--- a/src/resources/custom_biome/Stones/materials.json
+++ b/src/resources/custom_biome/Stones/materials.json
@@ -1,12 +1,12 @@
 {
   "name": "Stones",
   "texturePaths": [
-    "/env/paradise/layers/dirt000_albedo.dds",
     "/env/paradise/layers/grass001_albedo.dds",
     "/env/paradise/layers/Rock001_albedo.dds",
     "/env/paradise/layers/dirt000_albedo.dds",
     "/env/Evergreen2/Layers/EvRock005_albedo.dds",
     "/env/paradise/layers/sand000_albedo.dds",
+    "/env/paradise/layers/dirt000_albedo.dds",
     "/env/Geothermal/layers/Geo_LavaMd_02_albedo.dds",
     "/env/Geothermal/layers/Geo_Rock001_albedo.DDS",
     "/env/paradise/layers/LavaRock_albedo.dds",
@@ -16,41 +16,37 @@
     0.0,
     0.0,
     0.0,
-    0.0,
     12.0,
     16.0,
+    0.0,
     14.0,
     8.0,
     24.0,
     128.0
   ],
   "normalPaths": [
-    "/env/paradise/layers/grass000_normals.dds",
     "/env/paradise/layers/SandMed_normals.dds",
     "/env/paradise/layers/Rock001_normals.dds",
     "/env/paradise/layers/dirt000_normals.dds",
     "/env/paradise/layers/Rock001_normals.dds",
     "/env/paradise/layers/SandMed_normals.dds",
+    "/env/paradise/layers/grass000_normals.dds",
     "/env/paradise/layers/Rock001_normals.dds",
     "/env/paradise/layers/Rock001_normals.dds",
     "/env/paradise/layers/Rock001_normals.dds"
   ],
   "normalScales": [
-    4.0,
     24.0,
     16.0,
     16.0,
     16.0,
     64.0,
+    4.0,
     32.0,
     16.0,
     4.0
   ],
   "previewColors": [
-    {
-      "value": -10465488,
-      "falpha": 0.0
-    },
     {
       "value": -12767974,
       "falpha": 0.0
@@ -69,6 +65,10 @@
     },
     {
       "value": -8755895,
+      "falpha": 0.0
+    },
+    {
+      "value": -10465488,
       "falpha": 0.0
     },
     {

--- a/src/resources/custom_biome/Syrtis/materials.json
+++ b/src/resources/custom_biome/Syrtis/materials.json
@@ -1,56 +1,52 @@
 {
   "name": "Syrtis",
   "texturePaths": [
-    "/env/Red Barrens/Layers/RB_Sand_albedo.dds",
     "/env/Red Barrens/Layers/RB_Rock03_albedo.dds",
     "/env/Red Barrens/Layers/RB_Sandwet_albedo.dds",
     "/env/Red Barrens/Layers/RB_Sand_albedo.dds",
     "/env/Red Barrens/Layers/RB_RedMud_albedo.dds",
     "/env/Red Barrens/Layers/RB_Rock09_albedo.dds",
+    "/env/Red Barrens/Layers/RB_Sand_albedo.dds",
     "/env/Red Barrens/Layers/RB_Rock_albedo.DDS",
     "/env/Red Barrens/Layers/RB_Rock06_albedo.dds",
     "/env/Red Barrens/Layers/RB_Rock02_albedo.DDS",
     "/env/Red Barrens/Layers/macrotexture001_albedo.dds"
   ],
   "textureScales": [
-    4.0,
     2.0,
     6.0,
     0.0,
     32.0,
     16.0,
+    4.0,
     8.0,
     16.0,
     16.0,
     128.0
   ],
   "normalPaths": [
-    "/env/Red Barrens/Layers/RB_Rock06_normal.dds",
     "/env/Red Barrens/Layers/RB_RedMud_normal.dds",
     "/env/Red Barrens/Layers/RB_Cracked_normal.DDS",
     "/env/Red Barrens/Layers/RB_Sand_normal.dds",
     "/env/Red Barrens/Layers/RB_RedMud_normal.dds",
+    "/env/Red Barrens/Layers/RB_Rock06_normal.dds",
     "/env/Red Barrens/Layers/RB_Rock06_normal.dds",
     "/env/Red Barrens/Layers/RB_Rock09_normal.dds",
     "/env/Tundra/Layers/Tund_sandLight_normal.dds",
     "/env/Red Barrens/Layers/RB_Rock_normal.DDS"
   ],
   "normalScales": [
-    4.0,
     8.0,
     6.0,
     8.0,
     16.0,
     8.0,
+    4.0,
     16.0,
     4.0,
     16.0
   ],
   "previewColors": [
-    {
-      "value": -10080227,
-      "falpha": 0.0
-    },
     {
       "value": -9421518,
       "falpha": 0.0
@@ -69,6 +65,10 @@
     },
     {
       "value": -13100527,
+      "falpha": 0.0
+    },
+    {
+      "value": -10080227,
       "falpha": 0.0
     },
     {

--- a/src/resources/custom_biome/Wonder/materials.json
+++ b/src/resources/custom_biome/Wonder/materials.json
@@ -1,56 +1,52 @@
 {
   "name": "Wonder",
   "texturePaths": [
-    "/env/Evergreen2/Layers/Eg_Dirt002_albedo.dds",
     "/env/Evergreen2/Layers/EvGrass009_albedo.dds",
     "/env/Evergreen2/Layers/Eg_Dirt002_albedo.dds",
     "/env/Evergreen2/Layers/EvGrass005_albedo.dds",
     "/env/Evergreen2/Layers/EvGrass010a_albedo.dds",
     "/env/Evergreen2/Layers/EvRock002b_albedo.dds",
+    "/env/Evergreen2/Layers/Eg_Dirt002_albedo.dds",
     "/env/Evergreen2/Layers/EvRock006_albedo.dds",
     "/env/Evergreen2/Layers/EvRock006c_albedo.dds",
     "/env/Evergreen2/Layers/EvRock007_albedo.dds",
     "/env/Evergreen/layers/macrotexture000_albedo.dds"
   ],
   "textureScales": [
-    10.0,
     6.0,
     8.0,
     14.0,
     16.0,
     12.0,
+    10.0,
     13.0,
     32.0,
     16.0,
     128.0
   ],
   "normalPaths": [
-    "/env/Evergreen2/Layers/Eg_Gravel2_normal.dds",
     "/env/Evergreen2/Layers/EG_Grass002_normal.dds",
     "/env/Evergreen2/Layers/Eg_Gravel2_normal.dds",
     "/env/Evergreen2/Layers/EvTrans01_normals.dds",
     "/env/Evergreen2/Layers/EvTrans01_normals.dds",
     "/env/Evergreen2/Layers/EG_Gravel_normal.DDS",
+    "/env/Evergreen2/Layers/Eg_Gravel2_normal.dds",
     "/env/Evergreen2/Layers/EG_Rock_normal.dds",
     "/env/Evergreen2/Layers/EvRock006_normal.dds",
     "/env/Evergreen2/Layers/EvRock006_normal.dds"
   ],
   "normalScales": [
-    16.0,
     12.0,
     6.0,
     16.0,
     4.0,
     16.0,
     16.0,
+    16.0,
     20.0,
     8.0
   ],
   "previewColors": [
-    {
-      "value": -13160666,
-      "falpha": 0.0
-    },
     {
       "value": -14406639,
       "falpha": 0.0
@@ -69,6 +65,10 @@
     },
     {
       "value": -14801375,
+      "falpha": 0.0
+    },
+    {
+      "value": -13160666,
       "falpha": 0.0
     },
     {


### PR DESCRIPTION
Substantially changed how all texture layers/masks are used/calculated/determined/placed (slopes are much better represented, mountains/hills/ramps/etc are much more precise, textures are generally smoothed/blended a lot more, and more texture layers are now used sufficiently and generally with much greater levels of detail and more aesthetic qualities)
Removed ground texture layers/masks (layer 1)
Changed layer 0 from showing water/beach to showing ground
Moved texture layers/masks 2-6 down 1 layer each to now be layers 1-5
Added waterBeach texture layers/masks in layer slot 6
Added concurrent float/binary mask subtract functions (and imported visual debugger) to ConcurrentFloatMask.java
Created new concurrent and regular binary masks for better calculating/using texture layers (they are inland, highGround, aboveBeach, aboveBeachEdge, flatAboveCoast, higherFlatAboveCoast, and lowWaterBeach)