### PR TITLE
Updated QoL, options, and texture sizing-related improvements

### DIFF
--- a/src/java/generator/MapGenerator.java
+++ b/src/java/generator/MapGenerator.java
@@ -93,7 +93,7 @@ public strictfp class MapGenerator {
     private ConcurrentFloatMask accentSlopesTexture;
     private ConcurrentFloatMask accentPlateauTexture;
     private ConcurrentFloatMask slopesTexture;
-    private ConcurrentFloatMask rockBaseTexture;
+    private ConcurrentFloatMask steepHillsTexture;
     private ConcurrentFloatMask rockTexture;
     private ConcurrentFloatMask accentRockTexture;
     private ConcurrentBinaryMask rockDecal;
@@ -485,10 +485,10 @@ public strictfp class MapGenerator {
 
 
         CompletableFuture<Void> textureFuture = CompletableFuture.runAsync(() -> {
-            Pipeline.await(accentGroundTexture, accentPlateauTexture, slopesTexture, accentSlopesTexture, rockBaseTexture, waterBeachTexture, rockTexture, accentRockTexture);
+            Pipeline.await(accentGroundTexture, accentPlateauTexture, slopesTexture, accentSlopesTexture, steepHillsTexture, waterBeachTexture, rockTexture, accentRockTexture);
             long sTime = System.currentTimeMillis();
             map.setTextureMasksLowScaled(accentGroundTexture.getFinalMask(), accentPlateauTexture.getFinalMask(), slopesTexture.getFinalMask(), accentSlopesTexture.getFinalMask());
-            map.setTextureMasksHighScaled(rockBaseTexture.getFinalMask(), waterBeachTexture.getFinalMask(), rockTexture.getFinalMask(), accentRockTexture.getFinalMask());
+            map.setTextureMasksHighScaled(steepHillsTexture.getFinalMask(), waterBeachTexture.getFinalMask(), rockTexture.getFinalMask(), accentRockTexture.getFinalMask());
             if (DEBUG) {
                 System.out.printf("Done: %4d ms, %s, generateTextures\n",
                         System.currentTimeMillis() - sTime,
@@ -778,7 +778,7 @@ public strictfp class MapGenerator {
         ConcurrentBinaryMask accentPlateau = new ConcurrentBinaryMask(plateaus, random.nextLong(), "accentPlateau");
         ConcurrentBinaryMask slopes = new ConcurrentBinaryMask(slope, .1f, random.nextLong(), "slopes");
         ConcurrentBinaryMask accentSlopes = new ConcurrentBinaryMask(slope, .75f, random.nextLong(), "accentSlopes").invert();
-        ConcurrentBinaryMask rockBase = new ConcurrentBinaryMask(slope, .55f, random.nextLong(), "rockBase");
+        ConcurrentBinaryMask steepHills = new ConcurrentBinaryMask(slope, .55f, random.nextLong(), "steepHills");
         ConcurrentBinaryMask rock = new ConcurrentBinaryMask(slope, 1.25f, random.nextLong(), "rock");
         ConcurrentBinaryMask accentRock = new ConcurrentBinaryMask(slope, 1.25f, random.nextLong(), "accentRock");
         intDecal = new ConcurrentBinaryMask(land, random.nextLong(), "intDecal");
@@ -788,7 +788,7 @@ public strictfp class MapGenerator {
         accentPlateauTexture = new ConcurrentFloatMask(mapSize / 2, random.nextLong(), symmetrySettings, "accentPlateauTexture");
         slopesTexture = new ConcurrentFloatMask(mapSize / 2, random.nextLong(), symmetrySettings, "slopesTexture");
         accentSlopesTexture = new ConcurrentFloatMask(mapSize / 2, random.nextLong(), symmetrySettings, "accentSlopesTexture");
-        rockBaseTexture = new ConcurrentFloatMask(mapSize / 2, random.nextLong(), symmetrySettings, "rockBaseTexture");
+        steepHillsTexture = new ConcurrentFloatMask(mapSize / 2, random.nextLong(), symmetrySettings, "steepHillsTexture");
         rockTexture = new ConcurrentFloatMask(mapSize / 2, random.nextLong(), symmetrySettings, "rockTexture");
         accentRockTexture = new ConcurrentFloatMask(mapSize / 2, random.nextLong(), symmetrySettings, "accentRockTexture");
 
@@ -801,7 +801,7 @@ public strictfp class MapGenerator {
         accentPlateau.acid(.05f, 0).erode(.85f, symmetrySettings.getSpawnSymmetry()).smooth(2, .75f).acid(.45f, 0);
         slopes.intersect(land).flipValues(.95f).erode(.5f, symmetrySettings.getSpawnSymmetry()).acid(.3f, 0).erode(.2f, symmetrySettings.getSpawnSymmetry());
         accentSlopes.minus(flat).intersect(land).acid(.1f, 0).erode(.5f, symmetrySettings.getSpawnSymmetry()).smooth(4, .75f).acid(.55f, 0);
-        rockBase.acid(.3f, 0).erode(.2f, symmetrySettings.getSpawnSymmetry());
+        steepHills.acid(.3f, 0).erode(.2f, symmetrySettings.getSpawnSymmetry());
         accentRock.acid(.2f, 0).erode(.3f, symmetrySettings.getSpawnSymmetry()).acid(.2f, 0).smooth(2, .5f).intersect(rock);
 
         waterBeachTexture.init(waterBeach, 0, 1).subtract(rock, 1f).subtract(aboveBeachEdge, 1f).clampMin(0).smooth(2, rock.copy().invert()).add(waterBeach, 1f).subtract(rock, 1f);
@@ -812,7 +812,7 @@ public strictfp class MapGenerator {
         accentPlateauTexture.init(accentPlateau, 0, 1).smooth(8).add(accentPlateau, .65f).smooth(4).add(accentPlateau, .5f).smooth(1).clampMax(1f).threshold(.1f).smooth(2);
         slopesTexture.init(slopes, 0, 1).smooth(8).add(slopes, .65f).smooth(4).add(slopes, .5f).smooth(1).clampMax(1f).threshold(.05f).smooth(2);
         accentSlopesTexture.init(accentSlopes, 0, 1).smooth(8).add(accentSlopes, .65f).smooth(4).add(accentSlopes, .5f).smooth(1).clampMax(1f).threshold(.05f).smooth(2);
-        rockBaseTexture.init(rockBase, 0, 1).smooth(8).clampMax(0.35f).add(rockBase, .65f).smooth(4).clampMax(0.65f).add(rockBase, .5f).smooth(1).clampMax(1f).threshold(.1f).smooth(2);
+        steepHillsTexture.init(steepHills, 0, 1).smooth(8).clampMax(0.35f).add(steepHills, .65f).smooth(4).clampMax(0.65f).add(steepHills, .5f).smooth(1).clampMax(1f).threshold(.1f).smooth(2);
         rockTexture.init(rock, 0, 1).smooth(8).clampMax(0.2f).add(rock, .65f).smooth(4).clampMax(0.3f).add(rock, .5f).smooth(1).add(rock, 1f).clampMax(1f).threshold(.1f).smooth(2);
         accentRockTexture.init(accentRock, 0, 1).subtract(waterBeachTexture).clampMin(0).smooth(8).add(accentRock, .65f).smooth(4).add(accentRock, .5f).smooth(1).clampMax(1f).threshold(.1f).smooth(2);
 

--- a/src/java/map/FloatMask.java
+++ b/src/java/map/FloatMask.java
@@ -359,7 +359,7 @@ public strictfp class FloatMask extends Mask {
                         sum += get((x * oldSize / size) + z, (y * oldSize / size) + w);
                     }
                 }
-                smallMask[x][y] = sum / oldSize * size;
+                smallMask[x][y] = sum / oldSize * size / oldSize * size;
                 sum = 0;
             }
         }

--- a/src/java/map/FloatMask.java
+++ b/src/java/map/FloatMask.java
@@ -339,7 +339,7 @@ public strictfp class FloatMask extends Mask {
         int oldSize = getSize();
         for (int x = 0; x < size; x++) {
             for (int y = 0; y < size; y++) {
-                largeMask[x][y] = get(Math.round(x / (size / oldSize)), Math.round(y / (size / oldSize)));
+                largeMask[x][y] = get(StrictMath.round(x / (size / oldSize)), StrictMath.round(y / (size / oldSize)));
             }
         }
         mask = largeMask;

--- a/src/java/map/FloatMask.java
+++ b/src/java/map/FloatMask.java
@@ -176,6 +176,17 @@ public strictfp class FloatMask extends Mask {
         }
     }
 
+    public FloatMask clear() {
+        for (int x = 0; x < getSize(); x++) {
+            for (int y = 0; y < getSize(); y++) {
+                set(x, y, 0);
+            }
+        }
+        applySymmetry();
+        VisualDebugger.visualizeMask(this);
+        return this;
+    }
+
     public FloatMask multiply(FloatMask other) {
         for (int y = 0; y < getSize(); y++) {
             for (int x = 0; x < getSize(); x++) {
@@ -306,6 +317,58 @@ public strictfp class FloatMask extends Mask {
         return this;
     }
 
+    public FloatMask enlarge(int size) {
+        float[][] largeMask = new float[size][size];
+        int smallX;
+        int smallY;
+        for (int x = 0; x < size; x++) {
+            smallX = StrictMath.min(x / (size / getSize()), getSize() - 1);
+            for (int y = 0; y < size; y++) {
+                smallY = StrictMath.min(y / (size / getSize()), getSize() - 1);
+                largeMask[x][y] = get(smallX, smallY);
+            }
+        }
+        mask = largeMask;
+        applySymmetry(symmetrySettings.getSpawnSymmetry());
+        VisualDebugger.visualizeMask(this);
+        return this;
+    }
+
+    public FloatMask enlarge2 (int size) {
+        float[][] largeMask = new float[size][size];
+        int oldSize = getSize();
+        for (int x = 0; x < size; x++) {
+            for (int y = 0; y < size; y++) {
+                largeMask[x][y] = get(Math.round(x / (size / oldSize)), Math.round(y / (size / oldSize)));
+            }
+        }
+        mask = largeMask;
+        applySymmetry(symmetrySettings.getSpawnSymmetry());
+        VisualDebugger.visualizeMask(this);
+        return this;
+    }
+
+    public FloatMask shrink2 (int size) {
+        float[][] smallMask = new float[size][size];
+        int oldSize = getSize();
+        float sum = 0;
+        for (int x = 0; x < size; x++) {
+            for (int y = 0; y < size; y++) {
+                for (int z = 0; z < (oldSize / size); z++) {
+                    for (int w = 0; w < (oldSize / size); w++) {
+                        sum += get((x * oldSize / size) + z, (y * oldSize / size) + w);
+                    }
+                }
+                smallMask[x][y] = sum / oldSize * size;
+                sum = 0;
+            }
+        }
+        mask = smallMask;
+        applySymmetry(symmetrySettings.getSpawnSymmetry());
+        VisualDebugger.visualizeMask(this);
+        return this;
+    }
+
     public FloatMask shrink(int size) {
         float[][] smallMask = new float[size][size];
         int largeX;
@@ -324,6 +387,16 @@ public strictfp class FloatMask extends Mask {
         mask = smallMask;
         VisualDebugger.visualizeMask(this);
         applySymmetry(symmetrySettings.getTeamSymmetry());
+        return this;
+    }
+
+    public FloatMask setSize(int size) {
+        if (getSize() > size) {
+            shrink2(size);
+        }
+        if (getSize() < size) {
+            enlarge2(size);
+        }
         return this;
     }
 

--- a/src/java/util/Vector2f.java
+++ b/src/java/util/Vector2f.java
@@ -61,6 +61,12 @@ public strictfp class Vector2f {
         return this;
     }
 
+    public Vector2f clear() {
+        this.x = 0;
+        this.y = 0;
+        return this;
+    }
+
     public void flip(Vector2f center, Symmetry symmetry) {
         switch (symmetry) {
             case X -> x = 2 * center.x - x;


### PR DESCRIPTION
Added clear, enlarge, shrink2, enlarge2, and setSize FloatMask functions
Adjusted old texture masks to be copied before they are deleted
Applied new setSize function to old texture layer FloatMasks so that they are now relative to the map size
Enabled the user to functionally keep select texture layers while populating other texture layers
Added options for only replacing select texture layer masks
Adjusted decal deletion causes and added an option to prevent it
Added option for replacing the chosen texture layer mask with a new mask that is equivalent to shown layer 0 on the old map
Renamed rockBase to steepHills
Added Vector2f clear function
Misc minor formatting fixes