### PR TITLE
BinaryMask Brush-related Functions & Debugging Improvements

### DIFF
--- a/src/java/brushes/Brushes.java
+++ b/src/java/brushes/Brushes.java
@@ -19,10 +19,10 @@ public strictfp class Brushes {
 
     public static final List<String> goodBrushes = Arrays.asList("mountain1.png", "mountain2.png", "mountain4.png", "mountain5.png", "mountain6.png", "volcano2.png");
 
-    public static FloatMask loadBrush(String brushName, SymmetrySettings symmetrySettings) {
+    public static FloatMask loadBrush(String brushName, Long seed, SymmetrySettings symmetrySettings) {
         try {
             BufferedImage image = ImageUtils.readImage(CUSTOM_BRUSHES_DIR.concat(brushName));
-            return new FloatMask(image, null, symmetrySettings);
+            return new FloatMask(image, seed, symmetrySettings);
         } catch (Exception e) {
             e.printStackTrace();
             throw new RuntimeException("Could not load brush");

--- a/src/java/map/BinaryMask.java
+++ b/src/java/map/BinaryMask.java
@@ -175,7 +175,7 @@ public strictfp class BinaryMask extends Mask<Boolean> {
 
     public BinaryMask addFloatMaskValuesWithinRangeCenteredAtLocationWithSize(FloatMask other, float minValueToConvert, float maxValueToConvert, Vector2f location, int size) {
         if (size > getSize()) {
-            throw new IllegalArgumentException("Masks not the same size: other is " + other.getSize() + " and BinaryMask is " + getSize());
+            throw new IllegalArgumentException("Designated size of other mask is larger than BinaryMask: other is " + other.getSize() + " and BinaryMask is " + getSize());
         }
         BinaryMask maskToBeAdded = other.copy().setSize(size).convertToBinaryMask(minValueToConvert, maxValueToConvert);
         combineWithOffset(maskToBeAdded, location, true);
@@ -203,9 +203,9 @@ public strictfp class BinaryMask extends Mask<Boolean> {
         return this;
     }
 
-    public BinaryMask connectSpawnsWithRandomConsecutiveBrushUse(ArrayList<Spawn> spawns, int percentChanceToAttemptConnectionPerOddNumberedSpawn, String brushName, int size, int numberOfUsesBatchSize, float minIntensityForTrue, float maxIntensityForTrue, int maxDistanceBetweenBrushstrokeCenters) {
+    public BinaryMask connectSpawnsWithRandomConsecutiveBrushUse(ArrayList<Spawn> spawns, float probabilityToAttemptConnectionPerOddNumberedSpawn, String brushName, int size, int numberOfUsesBatchSize, float minIntensityForTrue, float maxIntensityForTrue, int maxDistanceBetweenBrushstrokeCenters) {
         for (int z = 0; z < spawns.size() / 2; z+=2) {
-            if(percentChanceToAttemptConnectionPerOddNumberedSpawn > random.nextInt(100) - 1) {
+            if(probabilityToAttemptConnectionPerOddNumberedSpawn > random.nextFloat()) {
                 Vector2f spawn = new Vector2f(spawns.get(z).getPosition().x, spawns.get(z).getPosition().z);
                 int halfSize = getSize() / 2;
                 while(!getValueAt(halfSize, halfSize)) {

--- a/src/java/map/ConcurrentBinaryMask.java
+++ b/src/java/map/ConcurrentBinaryMask.java
@@ -3,9 +3,11 @@ package map;
 import lombok.Getter;
 import util.Pipeline;
 import util.Util;
+import util.Vector2f;
 
 import java.nio.file.Path;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -84,6 +86,18 @@ public strictfp class ConcurrentBinaryMask extends ConcurrentMask<BinaryMask> {
     public ConcurrentBinaryMask flipValues(float density, Symmetry symmetry) {
         return Pipeline.add(this, Collections.singletonList(this), res ->
                 this.binaryMask.flipValues(density, symmetry)
+        );
+    }
+
+    public ConcurrentBinaryMask useBrushRepeatedlyForRandomConsecutiveExpansion(Vector2f startingLocation, String brushName, int size, int numberOfUses, float minIntensityForTrue, float maxIntensityForTrue, int maxDistanceBetweenBrushstrokeCenters) {
+        return Pipeline.add(this, Collections.singletonList(this), res ->
+                this.binaryMask.useBrushRepeatedlyForRandomConsecutiveExpansion(startingLocation, brushName, size, numberOfUses, minIntensityForTrue, maxIntensityForTrue, maxDistanceBetweenBrushstrokeCenters)
+        );
+    }
+
+    public ConcurrentBinaryMask connectSpawnsWithRandomConsecutiveBrushUse(ArrayList<Spawn> spawns, int percentChanceToAttemptConnectionPerOddNumberedSpawn, String brushName, int size, int numberOfUsesBatchSize, float minIntensityForTrue, float maxIntensityForTrue, int maxDistanceBetweenBrushstrokeCenters) {
+        return Pipeline.add(this, Collections.singletonList(this), res ->
+                this.binaryMask.connectSpawnsWithRandomConsecutiveBrushUse(spawns, percentChanceToAttemptConnectionPerOddNumberedSpawn, brushName, size, numberOfUsesBatchSize, minIntensityForTrue, maxIntensityForTrue, maxDistanceBetweenBrushstrokeCenters)
         );
     }
 
@@ -299,6 +313,11 @@ public strictfp class ConcurrentBinaryMask extends ConcurrentMask<BinaryMask> {
 
     public void show() {
         this.binaryMask.show();
+    }
+
+    public ConcurrentBinaryMask startVisualDebugger() {
+        this.binaryMask.startVisualDebugger(Util.getStackTraceParentClass());
+        return this;
     }
 
     public ConcurrentBinaryMask startVisualDebugger(String maskName) {

--- a/src/java/map/ConcurrentFloatMask.java
+++ b/src/java/map/ConcurrentFloatMask.java
@@ -238,6 +238,11 @@ public strictfp class ConcurrentFloatMask extends ConcurrentMask<FloatMask> {
         this.floatMask.show();
     }
 
+    public ConcurrentFloatMask startVisualDebugger() {
+        this.floatMask.startVisualDebugger(Util.getStackTraceParentClass());
+        return this;
+    }
+
     public ConcurrentFloatMask startVisualDebugger(String maskName) {
         this.floatMask.startVisualDebugger(maskName, Util.getStackTraceParentClass());
         return this;

--- a/src/java/map/FloatMask.java
+++ b/src/java/map/FloatMask.java
@@ -196,7 +196,7 @@ public strictfp class FloatMask extends Mask<Float> {
 
     public FloatMask init(BinaryMask other, float low, float high) {
         if (other.getSize() != getSize()) {
-            throw new IllegalArgumentException("Masks not the same size");
+            throw new IllegalArgumentException("Masks not the same size: other is " + other.getSize() + " and FloatMask is " + getSize());
         }
         for (int y = 0; y < getSize(); y++) {
             for (int x = 0; x < getSize(); x++) {
@@ -225,7 +225,7 @@ public strictfp class FloatMask extends Mask<Float> {
 
     public FloatMask multiply(FloatMask other) {
         if (other.getSize() != getSize()) {
-            throw new IllegalArgumentException("Masks not the same size");
+            throw new IllegalArgumentException("Masks not the same size: other is " + other.getSize() + " and FloatMask is " + getSize());
         }
         for (int y = 0; y < getSize(); y++) {
             for (int x = 0; x < getSize(); x++) {
@@ -273,7 +273,7 @@ public strictfp class FloatMask extends Mask<Float> {
 
     public FloatMask add(FloatMask other) {
         if (other.getSize() != getSize()) {
-            throw new IllegalArgumentException("Masks not the same size");
+            throw new IllegalArgumentException("Masks not the same size: other is " + other.getSize() + " and FloatMask is " + getSize());
         }
         for (int y = 0; y < getSize(); y++) {
             for (int x = 0; x < getSize(); x++) {
@@ -296,7 +296,7 @@ public strictfp class FloatMask extends Mask<Float> {
 
     public FloatMask subtract(FloatMask other) {
         if (other.getSize() != getSize()) {
-            throw new IllegalArgumentException("Masks not the same size");
+            throw new IllegalArgumentException("Masks not the same size: other is " + other.getSize() + " and FloatMask is " + getSize());
         }
         add(other.copy().multiplyAll(-1));
         VisualDebugger.visualizeMask(this);
@@ -346,7 +346,7 @@ public strictfp class FloatMask extends Mask<Float> {
 
     public FloatMask add(BinaryMask other, float value) {
         if (other.getSize() != getSize()) {
-            throw new IllegalArgumentException("Masks not the same size");
+            throw new IllegalArgumentException("Masks not the same size: other is " + other.getSize() + " and FloatMask is " + getSize());
         }
         FloatMask otherFloat = new FloatMask(getSize(), null, symmetrySettings);
         otherFloat.init(other, 0, value);
@@ -379,7 +379,7 @@ public strictfp class FloatMask extends Mask<Float> {
 
     public FloatMask subtract(BinaryMask other, float value) {
         if (other.getSize() != getSize()) {
-            throw new IllegalArgumentException("Masks not the same size");
+            throw new IllegalArgumentException("Masks not the same size: other is " + other.getSize() + " and FloatMask is " + getSize());
         }
         FloatMask otherFloat = new FloatMask(getSize(), null, symmetrySettings);
         otherFloat.init(other, 0, -value);
@@ -400,7 +400,7 @@ public strictfp class FloatMask extends Mask<Float> {
 
     public FloatMask min(FloatMask other) {
         if (other.getSize() != getSize()) {
-            throw new IllegalArgumentException("Masks not the same size");
+            throw new IllegalArgumentException("Masks not the same size: other is " + other.getSize() + " and FloatMask is " + getSize());
         }
         for (int y = 0; y < getSize(); y++) {
             for (int x = 0; x < getSize(); x++) {
@@ -532,7 +532,7 @@ public strictfp class FloatMask extends Mask<Float> {
 
     public FloatMask setNonZeroValues(FloatMask other) {
         if (other.getSize() != getSize()) {
-            throw new IllegalArgumentException("Masks not the same size");
+            throw new IllegalArgumentException("Masks not the same size: other is " + other.getSize() + " and FloatMask is " + getSize());
         }
         for (int x = 0; x < getSize(); x++) {
             for (int y = 0; y < getSize(); y++) {
@@ -547,7 +547,7 @@ public strictfp class FloatMask extends Mask<Float> {
 
     public FloatMask setToZeroForValue(BinaryMask other, boolean value) {
         if (other.getSize() != getSize()) {
-            throw new IllegalArgumentException("Masks not the same size");
+            throw new IllegalArgumentException("Masks not the same size: other is " + other.getSize() + " and FloatMask is " + getSize());
         }
         for (int x = 0; x < getSize(); x++) {
             for (int y = 0; y < getSize(); y++) {
@@ -580,7 +580,7 @@ public strictfp class FloatMask extends Mask<Float> {
 
     public FloatMask replaceValuesInRangeWith(BinaryMask range, FloatMask replacement) {
         if (range.getSize() != getSize() || replacement.getSize() != getSize()) {
-            throw new IllegalArgumentException("Masks not the same size");
+            throw new IllegalArgumentException("Masks not the same size: replacement is " + replacement.getSize() + " and FloatMask is " + getSize());
         }
         setToZeroForValue(range, true).add(replacement.copy().setToZeroForValue(range, false));
         VisualDebugger.visualizeMask(this);
@@ -589,7 +589,7 @@ public strictfp class FloatMask extends Mask<Float> {
 
     public FloatMask smoothWithinSpecifiedDistanceOfEdgesOf(BinaryMask other, int distance) {
         if (other.getSize() != getSize()) {
-            throw new IllegalArgumentException("Masks not the same size");
+            throw new IllegalArgumentException("Masks not the same size: other is " + other.getSize() + " and FloatMask is " + getSize());
         }
         for (int x = 0; x < distance; x = x + 2) {
             replaceValuesInRangeWith(other.getAreasWithinSpecifiedDistanceOfEdges(x + 1), copy().smooth(1));
@@ -600,7 +600,7 @@ public strictfp class FloatMask extends Mask<Float> {
 
     public FloatMask reduceValuesOnIntersectingSmoothingZones(BinaryMask avoidMakingZonesHere, float floatMax) {
         if (avoidMakingZonesHere.getSize() != getSize()) {
-            throw new IllegalArgumentException("Masks not the same size");
+            throw new IllegalArgumentException("Masks not the same size: avoidMakingZonesHere is " + avoidMakingZonesHere.getSize() + " and FloatMask is " + getSize());
         }
         avoidMakingZonesHere = avoidMakingZonesHere.copy();
         FloatMask newMaskInZones = copy().smooth(34).subtract(copy()).subtract(avoidMakingZonesHere, 1f * floatMax);
@@ -712,7 +712,7 @@ public strictfp class FloatMask extends Mask<Float> {
 
     public FloatMask smooth(int radius, BinaryMask limiter) {
         if (limiter.getSize() != getSize()) {
-            throw new IllegalArgumentException("Masks not the same size");
+            throw new IllegalArgumentException("Masks not the same size: limiter is " + limiter.getSize() + " and FloatMask is " + getSize());
         }
         int[][] innerCount = getInnerCount();
 
@@ -763,7 +763,7 @@ public strictfp class FloatMask extends Mask<Float> {
 
     public FloatMask spike(int radius, BinaryMask limiter) {
         if (limiter.getSize() != getSize()) {
-            throw new IllegalArgumentException("Masks not the same size");
+            throw new IllegalArgumentException("Masks not the same size: limiter is " + limiter.getSize() + " and FloatMask is " + getSize());
         }
         int[][] innerCount = getInnerCount();
 
@@ -800,7 +800,7 @@ public strictfp class FloatMask extends Mask<Float> {
     }
 
     public FloatMask useBrush(Vector2f location, String brushName, float intensity, int size) {
-        FloatMask brush = loadBrush(brushName, new SymmetrySettings(Symmetry.NONE, Symmetry.NONE, Symmetry.NONE));
+        FloatMask brush = loadBrush(brushName, random.nextLong(), new SymmetrySettings(Symmetry.NONE, Symmetry.NONE, Symmetry.NONE));
         brush.multiplyAll(intensity / brush.getMax());
         addFloatMaskCenteredAtLocationWithSize(brush, location, size);
         VisualDebugger.visualizeMask(this);
@@ -813,7 +813,7 @@ public strictfp class FloatMask extends Mask<Float> {
         }
         ArrayList<Vector2f> possibleLocations = new ArrayList<>(area.getAllCoordinatesEqualTo(true, 1));
         int length = possibleLocations.size();
-        FloatMask brush = loadBrush(brushName, new SymmetrySettings(Symmetry.NONE, Symmetry.NONE, Symmetry.NONE));
+        FloatMask brush = loadBrush(brushName, random.nextLong(), new SymmetrySettings(Symmetry.NONE, Symmetry.NONE, Symmetry.NONE));
         brush.multiplyAll(intensity / brush.getMax()).setSize(size);
         for (int z = 0; z < frequency; z++) {
             addWithOffset(brush, possibleLocations.get(random.nextInt(length)), true);
@@ -906,6 +906,10 @@ public strictfp class FloatMask extends Mask<Float> {
         return stringBuilder.toString();
     }
 
+
+    public FloatMask startVisualDebugger() {
+        return startVisualDebugger(toString(), Util.getStackTraceParentClass());
+    }
 
     public FloatMask startVisualDebugger(String maskName) {
         return startVisualDebugger(maskName, Util.getStackTraceParentClass());


### PR DESCRIPTION
Added BinaryMask functions: combineWithOffset, combineWithOffset, connectSpawnsWithRandomConsecutiveBrushUse, useBrushRepeatedlyForRandomConsecutiveExpansion and addFloatMaskValuesWithinRangeCenteredAtLocationWithSize
Added ConcurrentBinaryMask functions: useBrushRepeatedlyForRandomConsecutiveExpansion and connectSpawnsWithRandomConsecutiveBrushUse
Changed numerous functions' mask size error messages to be more detailed
Added automatically named visual debugging options
Added seed parameter for loadBrush function