### PR TITLE
New pathing functions and changes to support variable team count

### DIFF
--- a/src/java/map/BinaryMask.java
+++ b/src/java/map/BinaryMask.java
@@ -1050,18 +1050,10 @@ public strictfp class BinaryMask extends Mask<Boolean> {
             for (int i = 0; i < usesBatchSize; i++) {
                 x += (random.nextBoolean() ? 1 : -1) * random.nextInt(maxDistanceBetweenBrushUse + 1);
                 y += (random.nextBoolean() ? 1 : -1) * random.nextInt(maxDistanceBetweenBrushUse + 1);
-                if(x < 0) {
-                    x = 0;
-                }
-                if(x > mapSize) {
-                    x = mapSize;
-                }
-                if(y < 0) {
-                    y = 0;
-                }
-                if(y > mapSize) {
-                    y = mapSize;
-                }
+                x = StrictMath.min(x, mapSize);
+                x = StrictMath.max(x, 0);
+                y = StrictMath.min(y, mapSize);
+                y = StrictMath.max(y, 0);
                 combineWithOffset(brush, x, y, true);
             }
         }
@@ -1081,18 +1073,10 @@ public strictfp class BinaryMask extends Mask<Boolean> {
             for (int i = 0; i < usesBatchSize; i++) {
                 x += (random.nextBoolean() ? 1 : -1) * random.nextInt(maxDistanceBetweenBrushUse + 1);
                 y += (random.nextBoolean() ? 1 : -1) * random.nextInt(maxDistanceBetweenBrushUse + 1);
-                if(x < 0) {
-                    x = 0;
-                }
-                if(x > mapSize) {
-                    x = mapSize;
-                }
-                if(y < 0) {
-                    y = 0;
-                }
-                if(y > mapSize) {
-                    y = mapSize;
-                }
+                x = StrictMath.min(x, mapSize);
+                x = StrictMath.max(x, 0);
+                y = StrictMath.min(y, mapSize);
+                y = StrictMath.max(y, 0);
                 combineWithOffset(brush, x, y, true);
                 int finalY = y;
                 int finalX = x;

--- a/src/java/map/BinaryMask.java
+++ b/src/java/map/BinaryMask.java
@@ -1034,15 +1034,15 @@ public strictfp class BinaryMask extends Mask<Boolean> {
         return this;
     }
 
-    public BinaryMask connectLocationToNearItsSymmetricLocation(Vector2f startLocation, String brushName, int size, int usesBatchSize,
+    public BinaryMask connectLocationToNearItsSymLocation(Vector2f startLocation, String brushName, int size, int usesBatchSize,
                                            float minValue, float maxValue, int maxDistanceBetweenBrushUse, int minDistanceFromBrushCenterToSymLocationRequiredToCompleteFunction) {
         BinaryMask brush = ((FloatMask) loadBrush(brushName, random.nextLong(), new SymmetrySettings(Symmetry.NONE, Symmetry.NONE, Symmetry.NONE))
                 .setSize(size)).convertToBinaryMask(minValue, maxValue);
-        ArrayList<SymmetryPoint> symmetricalLocationList = getSymmetryPoints(startLocation);
-        Vector2f symmetricalLocation = symmetricalLocationList.get(0).getLocation();
+        ArrayList<SymmetryPoint> symLocationList = getSymmetryPoints(startLocation);
+        Vector2f symLocation = symLocationList.get(0).getLocation();
         int mapSize = getSize();
-        int symX = (int) symmetricalLocation.x;
-        int symY = (int) symmetricalLocation.y;
+        int symX = (int) symLocation.x;
+        int symY = (int) symLocation.y;
         int x = (int) startLocation.x;
         int y = (int) startLocation.y;
         while ((StrictMath.abs(x - symX) > minDistanceFromBrushCenterToSymLocationRequiredToCompleteFunction)
@@ -1104,7 +1104,7 @@ public strictfp class BinaryMask extends Mask<Boolean> {
         return this;
     }
 
-    public BinaryMask connectSpawnsWithRandomConsecutiveBrushUse(ArrayList<Spawn> spawns, int numberOfTeams, float probabilityToAttemptConnectionPerOddNumberedSpawn, String brushName, int size, int numberOfUsesBatchSize, float minIntensityForTrue, float maxIntensityForTrue, int maxDistanceBetweenBrushstrokeCenters, int minimumDistanceFromBrushCenterToSymmetricalLocationRequiredToCompleteFunction) {
+    public BinaryMask connectSpawnsWithRandomConsecutiveBrushUse(ArrayList<Spawn> spawns, int numberOfTeams, float probabilityToAttemptConnectionPerOddNumberedSpawn, String brushName, int size, int numberOfUsesBatchSize, float minIntensityForTrue, float maxIntensityForTrue, int maxDistanceBetweenBrushstrokeCenters, int minimumDistanceFromBrushCenterToSymLocationRequiredToCompleteFunction) {
         ArrayList<Vector2f> targetSpawns = new ArrayList<>();
         for (int z = spawns.size() / numberOfTeams; z < spawns.size(); z++) {
             targetSpawns.add(new Vector2f (spawns.get(z).getPosition().x, spawns.get(z).getPosition().z));
@@ -1112,18 +1112,18 @@ public strictfp class BinaryMask extends Mask<Boolean> {
         for (int z = 0; z < spawns.size() / numberOfTeams; z+=numberOfTeams) {
             if(probabilityToAttemptConnectionPerOddNumberedSpawn > random.nextFloat()) {
                 Vector2f spawn = new Vector2f(spawns.get(z).getPosition().x, spawns.get(z).getPosition().z);
-                connectLocationToNearAtLeastOneLocationFromList(spawn,targetSpawns, brushName, size, numberOfUsesBatchSize, minIntensityForTrue, maxIntensityForTrue, maxDistanceBetweenBrushstrokeCenters, minimumDistanceFromBrushCenterToSymmetricalLocationRequiredToCompleteFunction);
+                connectLocationToNearAtLeastOneLocationFromList(spawn,targetSpawns, brushName, size, numberOfUsesBatchSize, minIntensityForTrue, maxIntensityForTrue, maxDistanceBetweenBrushstrokeCenters, minimumDistanceFromBrushCenterToSymLocationRequiredToCompleteFunction);
             }
         }
         VisualDebugger.visualizeMask(this);
         return this;
     }
 
-    public BinaryMask connectSymSpawnsWithRandomConsecutiveBrushUse(ArrayList<Spawn> spawns, int numberOfTeams, float probabilityToAttemptConnectionPerOddNumberedSpawn, String brushName, int size, int numberOfUsesBatchSize, float minIntensityForTrue, float maxIntensityForTrue, int maxDistanceBetweenBrushstrokeCenters, int minimumDistanceFromBrushCenterToSymmetricalLocationRequiredToCompleteFunction) {
+    public BinaryMask connectSymSpawnsWithRandomConsecutiveBrushUse(ArrayList<Spawn> spawns, int numberOfTeams, float probabilityToAttemptConnectionPerOddNumberedSpawn, String brushName, int size, int numberOfUsesBatchSize, float minIntensityForTrue, float maxIntensityForTrue, int maxDistanceBetweenBrushstrokeCenters, int minimumDistanceFromBrushCenterToSymLocationRequiredToCompleteFunction) {
         for (int z = 0; z < spawns.size() / numberOfTeams; z+=numberOfTeams) {
             if(probabilityToAttemptConnectionPerOddNumberedSpawn > random.nextFloat()) {
                 Vector2f spawn = new Vector2f(spawns.get(z).getPosition().x, spawns.get(z).getPosition().z);
-                connectLocationToNearItsSymmetricLocation(spawn, brushName, size, numberOfUsesBatchSize, minIntensityForTrue, maxIntensityForTrue, maxDistanceBetweenBrushstrokeCenters, minimumDistanceFromBrushCenterToSymmetricalLocationRequiredToCompleteFunction);
+                connectLocationToNearItsSymLocation(spawn, brushName, size, numberOfUsesBatchSize, minIntensityForTrue, maxIntensityForTrue, maxDistanceBetweenBrushstrokeCenters, minimumDistanceFromBrushCenterToSymLocationRequiredToCompleteFunction);
             }
         }
         VisualDebugger.visualizeMask(this);

--- a/src/java/map/ConcurrentBinaryMask.java
+++ b/src/java/map/ConcurrentBinaryMask.java
@@ -88,9 +88,9 @@ public strictfp class ConcurrentBinaryMask extends ConcurrentMask<BinaryMask> {
         );
     }
 
-    public ConcurrentBinaryMask connectLocationToNearItsSymmetricLocation(Vector2f startingLocation, String brushName, int size, int numberOfUses, float minIntensityForTrue, float maxIntensityForTrue, int maxDistanceBetweenBrushstrokeCenters, int minimumDistanceFromBrushCenterToSymmetricalLocationRequiredToCompleteFunction) {
+    public ConcurrentBinaryMask connectLocationToNearItsSymLocation(Vector2f startingLocation, String brushName, int size, int numberOfUses, float minIntensityForTrue, float maxIntensityForTrue, int maxDistanceBetweenBrushstrokeCenters, int minimumDistanceFromBrushCenterToSymLocationRequiredToCompleteFunction) {
         return Pipeline.add(this, Collections.singletonList(this), res ->
-                this.mask.connectLocationToNearItsSymmetricLocation(startingLocation, brushName, size, numberOfUses, minIntensityForTrue, maxIntensityForTrue, maxDistanceBetweenBrushstrokeCenters, minimumDistanceFromBrushCenterToSymmetricalLocationRequiredToCompleteFunction)
+                this.mask.connectLocationToNearItsSymLocation(startingLocation, brushName, size, numberOfUses, minIntensityForTrue, maxIntensityForTrue, maxDistanceBetweenBrushstrokeCenters, minimumDistanceFromBrushCenterToSymLocationRequiredToCompleteFunction)
         );
     }
 

--- a/src/java/map/ConcurrentBinaryMask.java
+++ b/src/java/map/ConcurrentBinaryMask.java
@@ -94,9 +94,23 @@ public strictfp class ConcurrentBinaryMask extends ConcurrentMask<BinaryMask> {
         );
     }
 
-    public ConcurrentBinaryMask connectSpawnsWithRandomConsecutiveBrushUse(ArrayList<Spawn> spawns, float probabilityToAttemptConnectionPerOddNumberedSpawn, String brushName, int size, int numberOfUsesBatchSize, float minIntensityForTrue, float maxIntensityForTrue, int maxDistanceBetweenBrushstrokeCenters, int minDistanceFromBrushCenterToSymLocationRequiredToCompleteFunction) {
+    public ConcurrentBinaryMask connectSpawnsWithRandomConsecutiveBrushUse(ArrayList<Spawn> spawns, int numberOfTeams, float probabilityToAttemptConnectionPerOddNumberedSpawn, String brushName, int size, int numberOfUsesBatchSize, float minIntensityForTrue, float maxIntensityForTrue, int maxDistanceBetweenBrushstrokeCenters, int minDistanceFromBrushCenterToSymLocationRequiredToCompleteFunction) {
         return Pipeline.add(this, Collections.singletonList(this), res ->
-                this.mask.connectSpawnsWithRandomConsecutiveBrushUse(spawns, probabilityToAttemptConnectionPerOddNumberedSpawn, brushName, size, numberOfUsesBatchSize, minIntensityForTrue, maxIntensityForTrue, maxDistanceBetweenBrushstrokeCenters, minDistanceFromBrushCenterToSymLocationRequiredToCompleteFunction)
+                this.mask.connectSymSpawnsWithRandomConsecutiveBrushUse(spawns, numberOfTeams, probabilityToAttemptConnectionPerOddNumberedSpawn, brushName, size, numberOfUsesBatchSize, minIntensityForTrue, maxIntensityForTrue, maxDistanceBetweenBrushstrokeCenters, minDistanceFromBrushCenterToSymLocationRequiredToCompleteFunction)
+        );
+    }
+
+    public ConcurrentBinaryMask connectLocationToNearAtLeastOneLocationFromList(Vector2f startLocation, ArrayList<Vector2f> targetLocations, String brushName, int size, int usesBatchSize, float minValue, float maxValue, int maxDistanceBetweenBrushUse, int minDistanceFromBrushCenterToSymLocationRequiredToCompleteFunction) {
+        return Pipeline.add(this, Collections.singletonList(this), res ->
+                this.mask.connectLocationToNearAtLeastOneLocationFromList(startLocation, targetLocations, brushName, size, usesBatchSize,
+        minValue, maxValue, maxDistanceBetweenBrushUse, minDistanceFromBrushCenterToSymLocationRequiredToCompleteFunction)
+        );
+    }
+
+
+    public ConcurrentBinaryMask connectSymSpawnsWithRandomConsecutiveBrushUse(ArrayList<Spawn> spawns, int numberOfTeams, float probabilityToAttemptConnectionPerOddNumberedSpawn, String brushName, int size, int numberOfUsesBatchSize, float minIntensityForTrue, float maxIntensityForTrue, int maxDistanceBetweenBrushstrokeCenters, int minDistanceFromBrushCenterToSymLocationRequiredToCompleteFunction) {
+        return Pipeline.add(this, Collections.singletonList(this), res ->
+                this.mask.connectSymSpawnsWithRandomConsecutiveBrushUse(spawns, numberOfTeams, probabilityToAttemptConnectionPerOddNumberedSpawn, brushName, size, numberOfUsesBatchSize, minIntensityForTrue, maxIntensityForTrue, maxDistanceBetweenBrushstrokeCenters, minDistanceFromBrushCenterToSymLocationRequiredToCompleteFunction)
         );
     }
 

--- a/src/java/map/ConcurrentBinaryMask.java
+++ b/src/java/map/ConcurrentBinaryMask.java
@@ -7,6 +7,7 @@ import util.Vector2f;
 
 import java.nio.file.Path;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -84,6 +85,18 @@ public strictfp class ConcurrentBinaryMask extends ConcurrentMask<BinaryMask> {
     public ConcurrentBinaryMask useBrushRepeatedlyForRandomConsecutiveExpansion(Vector2f startingLocation, String brushName, int size, int numberOfUses, float minIntensityForTrue, float maxIntensityForTrue, int maxDistanceBetweenBrushstrokeCenters) {
         return Pipeline.add(this, Collections.singletonList(this), res ->
                 this.mask.useBrushForExpansion(startingLocation, brushName, size, numberOfUses, minIntensityForTrue, maxIntensityForTrue, maxDistanceBetweenBrushstrokeCenters)
+        );
+    }
+
+    public ConcurrentBinaryMask connectLocationToNearItsSymmetricLocation(Vector2f startingLocation, String brushName, int size, int numberOfUses, float minIntensityForTrue, float maxIntensityForTrue, int maxDistanceBetweenBrushstrokeCenters, int minimumDistanceFromBrushCenterToSymmetricalLocationRequiredToCompleteFunction) {
+        return Pipeline.add(this, Collections.singletonList(this), res ->
+                this.mask.connectLocationToNearItsSymmetricLocation(startingLocation, brushName, size, numberOfUses, minIntensityForTrue, maxIntensityForTrue, maxDistanceBetweenBrushstrokeCenters, minimumDistanceFromBrushCenterToSymmetricalLocationRequiredToCompleteFunction)
+        );
+    }
+
+    public ConcurrentBinaryMask connectSpawnsWithRandomConsecutiveBrushUse(ArrayList<Spawn> spawns, float probabilityToAttemptConnectionPerOddNumberedSpawn, String brushName, int size, int numberOfUsesBatchSize, float minIntensityForTrue, float maxIntensityForTrue, int maxDistanceBetweenBrushstrokeCenters, int minDistanceFromBrushCenterToSymLocationRequiredToCompleteFunction) {
+        return Pipeline.add(this, Collections.singletonList(this), res ->
+                this.mask.connectSpawnsWithRandomConsecutiveBrushUse(spawns, probabilityToAttemptConnectionPerOddNumberedSpawn, brushName, size, numberOfUsesBatchSize, minIntensityForTrue, maxIntensityForTrue, maxDistanceBetweenBrushstrokeCenters, minDistanceFromBrushCenterToSymLocationRequiredToCompleteFunction)
         );
     }
 


### PR DESCRIPTION
Created ConcurrentBinaryMasks: connectedSpawnsWithRandomConsecutiveBrushUse, connectLocationToNearItsSymmetricLocation, connectSymSpawnsWithRandomConsecutiveBrushUse and connectLocationToNearAtLeastOneLocationFromList

Created BinaryMasks: connectSpawnsWithRandomConsecutiveBrushUse, connectLocationToNearItsSymmetricLocation, connectSymSpawnsWithRandomConsecutiveBrushUse and connectLocationToNearAtLeastOneLocationFromList