### PR TITLE
Change minimap colors to match gpg maps

### DIFF
--- a/shared/src/main/java/com/faforever/neroxis/map/SCMap.java
+++ b/shared/src/main/java/com/faforever/neroxis/map/SCMap.java
@@ -91,12 +91,12 @@ public class SCMap {
     private BufferedImage waterFlatnessMap;
     private BufferedImage waterDepthBiasMap;
     private BufferedImage terrainType;
-    private int cartographicContourInterval = 1000;
-    private int cartographicDeepWaterColor = new Color(0, 34, 255).getRGB();
-    private int cartographicMapContourColor = new Color(255, 0, 0).getRGB();
-    private int cartographicMapShoreColor = new Color(161, 192, 255).getRGB();
-    private int cartographicMapLandStartColor = new Color(255, 255, 255).getRGB();
-    private int cartographicMapLandEndColor = new Color(0, 0, 0).getRGB();
+    private int cartographicContourInterval = 100;
+    private int cartographicDeepWaterColor = new Color(71, 140, 181).getRGB();
+    private int cartographicMapContourColor = new Color(0, 0, 0).getRGB();
+    private int cartographicMapShoreColor = new Color(141, 200, 225).getRGB();
+    private int cartographicMapLandStartColor = new Color(119, 101, 108).getRGB();
+    private int cartographicMapLandEndColor = new Color(206, 206, 176).getRGB();
 
     public SCMap(int size, Biome biome) {
         this.size = size;


### PR DESCRIPTION

![Screenshot 2023-12-05 150936](https://github.com/FAForever/Neroxis-Map-Generator/assets/52536103/31a6f4f3-3a49-4976-82f3-a6ed6b8c76d1)

The reduction of cartographicContourInterval actually has no effect. Further reducing it to 50 had an effect, so maybe it is capped at 64, but I didn't investigate further. I put it to 100 to bring it closer to the actual cap. On my first try where I reduced it from 1000 to 100 I saw no effect, which was confusing.
The default on gpg maps is 10. 

Based on this thread https://forum.faforever.com/topic/6874/opinions-on-minimap-colors-wanted
