### PR TITLE
Add boulder field prop generator

### DIFF
--- a/generator/src/main/java/com/faforever/neroxis/generator/PropStyle.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/PropStyle.java
@@ -1,6 +1,7 @@
 package com.faforever.neroxis.generator;
 
 import com.faforever.neroxis.generator.prop.BasicPropGenerator;
+import com.faforever.neroxis.generator.prop.BoulderFieldPropGenerator;
 import com.faforever.neroxis.generator.prop.EnemyCivPropGenerator;
 import com.faforever.neroxis.generator.prop.HighReclaimPropGenerator;
 import com.faforever.neroxis.generator.prop.LargeBattlePropGenerator;
@@ -17,6 +18,7 @@ import java.util.function.Supplier;
 @AllArgsConstructor
 public enum PropStyle {
     BASIC(BasicPropGenerator.class, BasicPropGenerator::new),
+    BOULDER_FIELD(BoulderFieldPropGenerator.class, BoulderFieldPropGenerator::new),
     ENEMY_CIV(EnemyCivPropGenerator.class, EnemyCivPropGenerator::new),
     HIGH_RECLAIM(HighReclaimPropGenerator.class, HighReclaimPropGenerator::new),
     LARGE_BATTLE(LargeBattlePropGenerator.class, LargeBattlePropGenerator::new),

--- a/generator/src/main/java/com/faforever/neroxis/generator/prop/BoulderFieldPropGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/prop/BoulderFieldPropGenerator.java
@@ -1,0 +1,74 @@
+package com.faforever.neroxis.generator.prop;
+
+import com.faforever.neroxis.biomes.Biome;
+import com.faforever.neroxis.generator.GeneratorParameters;
+import com.faforever.neroxis.generator.terrain.TerrainGenerator;
+import com.faforever.neroxis.map.SCMap;
+import com.faforever.neroxis.map.SymmetrySettings;
+import com.faforever.neroxis.mask.BooleanMask;
+import com.faforever.neroxis.util.DebugUtil;
+import com.faforever.neroxis.util.Pipeline;
+
+public class BoulderFieldPropGenerator extends BasicPropGenerator {
+    protected BooleanMask fieldBoulderMask;
+    protected BooleanMask boulderReclaimAreaMask;
+    protected BooleanMask stoneReclaimAreaMask;
+
+    @Override
+    public void initialize(SCMap map, long seed, GeneratorParameters generatorParameters,
+                           SymmetrySettings symmetrySettings, TerrainGenerator terrainGenerator) {
+        super.initialize(map, seed, generatorParameters, symmetrySettings, terrainGenerator);
+        fieldBoulderMask = new BooleanMask(1, random.nextLong(), symmetrySettings, "fieldBoulderMask", true);
+        boulderReclaimAreaMask = new BooleanMask(1, random.nextLong(), symmetrySettings, "boulderReclaimAreaMask", true);
+        stoneReclaimAreaMask = new BooleanMask(1, random.nextLong(), symmetrySettings, "stoneReclaimAreaMask", true);
+    }
+
+    @Override
+    public void placePropsWithExclusion() {
+        Pipeline.await(treeMask, cliffRockMask, fieldStoneMask, fieldBoulderMask, stoneReclaimAreaMask, boulderReclaimAreaMask);
+        DebugUtil.timedRun("com.faforever.neroxis.map.generator", "placeProps", () -> {
+            Biome biome = map.getBiome();
+            propPlacer.placeProps(treeMask.getFinalMask().subtract(noProps), biome.propMaterials().treeGroups(),
+                    3f, 7f);
+            propPlacer.placeProps(cliffRockMask.getFinalMask(), biome.propMaterials().rocks(), .6f, 2.5f);
+            propPlacer.placeProps(fieldStoneMask.getFinalMask().subtract(noProps),
+                    biome.propMaterials().rocks(), .5f, 2.5f);
+            propPlacer.placeProps(fieldBoulderMask.getFinalMask().subtract(noProps),
+                    biome.propMaterials().boulders(), 5f, 10f);
+            propPlacer.placeProps(stoneReclaimAreaMask.getFinalMask().subtract(noProps),
+                    biome.propMaterials().rocks(), 1f, 3f);
+            propPlacer.placeProps(boulderReclaimAreaMask.getFinalMask().subtract(noProps),
+                    biome.propMaterials().boulders(), 3f, 5f);
+        });
+    }
+
+    @Override
+    protected void setupPropPipeline() {
+        int mapSize = map.getSize();
+        float reclaimDensity = random.nextFloat() * 0.6f + 0.4f;
+        int spawnCount = generatorParameters.spawnCount();
+        treeMask.setSize(mapSize / 16);
+        cliffRockMask.setSize(mapSize / 32);
+        fieldBoulderMask.setSize(mapSize / 4);
+        boulderReclaimAreaMask.setSize(mapSize / 4);
+
+        BooleanMask reclaimArea = new BooleanMask(1, random.nextLong(), symmetrySettings, "reclaimArea", true);
+        reclaimArea.setSize(mapSize / 4);
+        reclaimArea.randomize(reclaimDensity * spawnCount * .0005f).dilute(.8f, 4).setSize(mapSize + 1);
+        boulderReclaimAreaMask.randomize(0.5f).setSize(mapSize + 1).multiply(reclaimArea);
+        stoneReclaimAreaMask.init(boulderReclaimAreaMask).dilute(.5f, 2).subtract(boulderReclaimAreaMask).dilute(.5f);
+        boulderReclaimAreaMask.multiply(passableLand).fillEdge(10, false);
+        stoneReclaimAreaMask.multiply(passableLand).fillEdge(9, false);
+
+        cliffRockMask.randomize(reclaimDensity * .5f).setSize(mapSize + 1);
+        cliffRockMask.multiply(impassable).dilute(.5f, 10).subtract(impassable).multiply(passableLand);
+        fieldBoulderMask.randomize(reclaimDensity * spawnCount * .0025f).setSize(mapSize + 1);
+        fieldBoulderMask.multiply(passableLand).fillEdge(10, false);
+        fieldStoneMask.init(fieldBoulderMask).dilute(.5f, 6).subtract(fieldBoulderMask).erode(.3f);
+        treeMask.randomize((reclaimDensity + random.nextFloat()) / 2f * .15f).setSize(mapSize / 4);
+        treeMask.inflate(2).erode(.5f);
+        treeMask.setSize(mapSize + 1);
+        treeMask.subtract(boulderReclaimAreaMask).subtract(stoneReclaimAreaMask.copy().dilute(.8f, 2)).subtract(fieldBoulderMask);
+        treeMask.multiply(passableLand.copy().deflate(8)).fillEdge(8, false);
+    }
+}

--- a/generator/src/main/java/com/faforever/neroxis/generator/style/BasicStyleGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/style/BasicStyleGenerator.java
@@ -3,7 +3,9 @@ package com.faforever.neroxis.generator.style;
 import com.faforever.neroxis.generator.WeightedOption;
 import com.faforever.neroxis.generator.WeightedOptionsWithFallback;
 import com.faforever.neroxis.generator.prop.BasicPropGenerator;
+import com.faforever.neroxis.generator.prop.BoulderFieldPropGenerator;
 import com.faforever.neroxis.generator.prop.EnemyCivPropGenerator;
+import com.faforever.neroxis.generator.prop.HighReclaimPropGenerator;
 import com.faforever.neroxis.generator.prop.LargeBattlePropGenerator;
 import com.faforever.neroxis.generator.prop.NavyWrecksPropGenerator;
 import com.faforever.neroxis.generator.prop.NeutralCivPropGenerator;
@@ -19,7 +21,9 @@ public class BasicStyleGenerator extends StyleGenerator {
     protected WeightedOptionsWithFallback<PropGenerator> getPropGeneratorOptions() {
         return WeightedOptionsWithFallback.of(new BasicPropGenerator(),
                                               new WeightedOption<>(new BasicPropGenerator(), 1f),
+                                              new WeightedOption<>(new BoulderFieldPropGenerator(), 1f),
                                               new WeightedOption<>(new EnemyCivPropGenerator(), .5f),
+                                              new WeightedOption<>(new HighReclaimPropGenerator(), .5f),
                                               new WeightedOption<>(new LargeBattlePropGenerator(), 2f),
                                               new WeightedOption<>(new NavyWrecksPropGenerator(), 2f),
                                               new WeightedOption<>(new NeutralCivPropGenerator(), 1f),

--- a/generator/src/main/java/com/faforever/neroxis/generator/style/BigIslandsStyleGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/style/BigIslandsStyleGenerator.java
@@ -4,6 +4,7 @@ import com.faforever.neroxis.generator.ParameterConstraints;
 import com.faforever.neroxis.generator.WeightedOption;
 import com.faforever.neroxis.generator.WeightedOptionsWithFallback;
 import com.faforever.neroxis.generator.prop.BasicPropGenerator;
+import com.faforever.neroxis.generator.prop.BoulderFieldPropGenerator;
 import com.faforever.neroxis.generator.prop.EnemyCivPropGenerator;
 import com.faforever.neroxis.generator.prop.NavyWrecksPropGenerator;
 import com.faforever.neroxis.generator.prop.NeutralCivPropGenerator;
@@ -29,11 +30,12 @@ public class BigIslandsStyleGenerator extends StyleGenerator {
     protected WeightedOptionsWithFallback<PropGenerator> getPropGeneratorOptions() {
         return WeightedOptionsWithFallback.of(new BasicPropGenerator(),
                                               new WeightedOption<>(new BasicPropGenerator(), 1f),
+                                              new WeightedOption<>(new BoulderFieldPropGenerator(), 1f),
+                                              new WeightedOption<>(new EnemyCivPropGenerator(), .5f),
+                                              new WeightedOption<>(new NavyWrecksPropGenerator(), 2),
                                               new WeightedOption<>(new NeutralCivPropGenerator(), 1f),
                                               new WeightedOption<>(new RockFieldPropGenerator(), 1f),
-                                              new WeightedOption<>(new SmallBattlePropGenerator(), 1f),
-                                              new WeightedOption<>(new EnemyCivPropGenerator(), .5f),
-                                              new WeightedOption<>(new NavyWrecksPropGenerator(), 2));
+                                              new WeightedOption<>(new SmallBattlePropGenerator(), 1f));
     }
 }
 

--- a/generator/src/main/java/com/faforever/neroxis/generator/style/CenterLakeStyleGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/style/CenterLakeStyleGenerator.java
@@ -4,6 +4,7 @@ import com.faforever.neroxis.generator.ParameterConstraints;
 import com.faforever.neroxis.generator.WeightedOption;
 import com.faforever.neroxis.generator.WeightedOptionsWithFallback;
 import com.faforever.neroxis.generator.prop.BasicPropGenerator;
+import com.faforever.neroxis.generator.prop.BoulderFieldPropGenerator;
 import com.faforever.neroxis.generator.prop.EnemyCivPropGenerator;
 import com.faforever.neroxis.generator.prop.NavyWrecksPropGenerator;
 import com.faforever.neroxis.generator.prop.NeutralCivPropGenerator;
@@ -31,11 +32,12 @@ public class CenterLakeStyleGenerator extends StyleGenerator {
     protected WeightedOptionsWithFallback<PropGenerator> getPropGeneratorOptions() {
         return WeightedOptionsWithFallback.of(new BasicPropGenerator(),
                                               new WeightedOption<>(new BasicPropGenerator(), 1f),
+                                              new WeightedOption<>(new BoulderFieldPropGenerator(), 1f),
+                                              new WeightedOption<>(new EnemyCivPropGenerator(), .5f),
+                                              new WeightedOption<>(new NavyWrecksPropGenerator(), 2),
                                               new WeightedOption<>(new NeutralCivPropGenerator(), 1f),
                                               new WeightedOption<>(new RockFieldPropGenerator(), 1f),
-                                              new WeightedOption<>(new SmallBattlePropGenerator(), 1f),
-                                              new WeightedOption<>(new EnemyCivPropGenerator(), .5f),
-                                              new WeightedOption<>(new NavyWrecksPropGenerator(), 2));
+                                              new WeightedOption<>(new SmallBattlePropGenerator(), 1f));
     }
 }
 

--- a/generator/src/main/java/com/faforever/neroxis/generator/style/DropPlateauStyleGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/style/DropPlateauStyleGenerator.java
@@ -3,6 +3,7 @@ package com.faforever.neroxis.generator.style;
 import com.faforever.neroxis.generator.WeightedOption;
 import com.faforever.neroxis.generator.WeightedOptionsWithFallback;
 import com.faforever.neroxis.generator.prop.BasicPropGenerator;
+import com.faforever.neroxis.generator.prop.BoulderFieldPropGenerator;
 import com.faforever.neroxis.generator.prop.EnemyCivPropGenerator;
 import com.faforever.neroxis.generator.prop.HighReclaimPropGenerator;
 import com.faforever.neroxis.generator.prop.LargeBattlePropGenerator;
@@ -24,12 +25,13 @@ public class DropPlateauStyleGenerator extends StyleGenerator {
     protected WeightedOptionsWithFallback<PropGenerator> getPropGeneratorOptions() {
         return WeightedOptionsWithFallback.of(new BasicPropGenerator(),
                                               new WeightedOption<>(new BasicPropGenerator(), 1f),
+                                              new WeightedOption<>(new BoulderFieldPropGenerator(), 1f),
                                               new WeightedOption<>(new EnemyCivPropGenerator(), .5f),
+                                              new WeightedOption<>(new HighReclaimPropGenerator(), .5f),
                                               new WeightedOption<>(new LargeBattlePropGenerator(), 2f),
                                               new WeightedOption<>(new NeutralCivPropGenerator(), 1f),
                                               new WeightedOption<>(new RockFieldPropGenerator(), 1f),
-                                              new WeightedOption<>(new SmallBattlePropGenerator(), 1f),
-                                              new WeightedOption<>(new HighReclaimPropGenerator(), .5f));
+                                              new WeightedOption<>(new SmallBattlePropGenerator(), 1f));
     }
 }
 

--- a/generator/src/main/java/com/faforever/neroxis/generator/style/HighReclaimStyleGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/style/HighReclaimStyleGenerator.java
@@ -2,6 +2,7 @@ package com.faforever.neroxis.generator.style;
 
 import com.faforever.neroxis.generator.WeightedOption;
 import com.faforever.neroxis.generator.WeightedOptionsWithFallback;
+import com.faforever.neroxis.generator.prop.BoulderFieldPropGenerator;
 import com.faforever.neroxis.generator.prop.HighReclaimPropGenerator;
 import com.faforever.neroxis.generator.prop.PropGenerator;
 import com.faforever.neroxis.generator.terrain.BasicTerrainGenerator;
@@ -30,7 +31,9 @@ public class HighReclaimStyleGenerator extends StyleGenerator {
 
     @Override
     protected WeightedOptionsWithFallback<PropGenerator> getPropGeneratorOptions() {
-        return WeightedOptionsWithFallback.of(new HighReclaimPropGenerator());
+        return WeightedOptionsWithFallback.of(new HighReclaimPropGenerator(),
+                                              new WeightedOption<>(new HighReclaimPropGenerator(), 1f),
+                                              new WeightedOption<>(new BoulderFieldPropGenerator(), 1f));
     }
 
     @Override

--- a/generator/src/main/java/com/faforever/neroxis/generator/style/LandBridgeStyleGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/style/LandBridgeStyleGenerator.java
@@ -3,6 +3,7 @@ package com.faforever.neroxis.generator.style;
 import com.faforever.neroxis.generator.ParameterConstraints;
 import com.faforever.neroxis.generator.WeightedOption;
 import com.faforever.neroxis.generator.WeightedOptionsWithFallback;
+import com.faforever.neroxis.generator.prop.BoulderFieldPropGenerator;
 import com.faforever.neroxis.generator.prop.LargeBattlePropGenerator;
 import com.faforever.neroxis.generator.prop.NavyWrecksPropGenerator;
 import com.faforever.neroxis.generator.prop.NeutralCivPropGenerator;
@@ -30,11 +31,12 @@ public class LandBridgeStyleGenerator extends StyleGenerator {
     @Override
     protected WeightedOptionsWithFallback<PropGenerator> getPropGeneratorOptions() {
         return WeightedOptionsWithFallback.of(new LargeBattlePropGenerator(),
+                                              new WeightedOption<>(new BoulderFieldPropGenerator(), 1f),
                                               new WeightedOption<>(new LargeBattlePropGenerator(), 2f),
+                                              new WeightedOption<>(new NavyWrecksPropGenerator(), 2f),
                                               new WeightedOption<>(new NeutralCivPropGenerator(), 1f),
                                               new WeightedOption<>(new RockFieldPropGenerator(), 1f),
-                                              new WeightedOption<>(new SmallBattlePropGenerator(), 1f),
-                                              new WeightedOption<>(new NavyWrecksPropGenerator(), 2f));
+                                              new WeightedOption<>(new SmallBattlePropGenerator(), 1f));
     }
 
     @Override

--- a/generator/src/main/java/com/faforever/neroxis/generator/style/LittleMountainStyleGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/style/LittleMountainStyleGenerator.java
@@ -3,6 +3,7 @@ package com.faforever.neroxis.generator.style;
 import com.faforever.neroxis.generator.WeightedOption;
 import com.faforever.neroxis.generator.WeightedOptionsWithFallback;
 import com.faforever.neroxis.generator.prop.BasicPropGenerator;
+import com.faforever.neroxis.generator.prop.BoulderFieldPropGenerator;
 import com.faforever.neroxis.generator.prop.EnemyCivPropGenerator;
 import com.faforever.neroxis.generator.prop.HighReclaimPropGenerator;
 import com.faforever.neroxis.generator.prop.LargeBattlePropGenerator;
@@ -24,11 +25,12 @@ public class LittleMountainStyleGenerator extends StyleGenerator {
     protected WeightedOptionsWithFallback<PropGenerator> getPropGeneratorOptions() {
         return WeightedOptionsWithFallback.of(new BasicPropGenerator(),
                                               new WeightedOption<>(new BasicPropGenerator(), 1f),
+                                              new WeightedOption<>(new BoulderFieldPropGenerator(), 1f),
                                               new WeightedOption<>(new EnemyCivPropGenerator(), .5f),
+                                              new WeightedOption<>(new HighReclaimPropGenerator(), .5f),
                                               new WeightedOption<>(new LargeBattlePropGenerator(), 2f),
                                               new WeightedOption<>(new NeutralCivPropGenerator(), 1f),
                                               new WeightedOption<>(new RockFieldPropGenerator(), 1f),
-                                              new WeightedOption<>(new SmallBattlePropGenerator(), 1f),
-                                              new WeightedOption<>(new HighReclaimPropGenerator(), .5f));
+                                              new WeightedOption<>(new SmallBattlePropGenerator(), 1f));
     }
 }

--- a/generator/src/main/java/com/faforever/neroxis/generator/style/LowMexStyleGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/style/LowMexStyleGenerator.java
@@ -4,6 +4,7 @@ import com.faforever.neroxis.generator.ParameterConstraints;
 import com.faforever.neroxis.generator.WeightedOption;
 import com.faforever.neroxis.generator.WeightedOptionsWithFallback;
 import com.faforever.neroxis.generator.prop.BasicPropGenerator;
+import com.faforever.neroxis.generator.prop.BoulderFieldPropGenerator;
 import com.faforever.neroxis.generator.prop.EnemyCivPropGenerator;
 import com.faforever.neroxis.generator.prop.HighReclaimPropGenerator;
 import com.faforever.neroxis.generator.prop.LargeBattlePropGenerator;
@@ -49,13 +50,14 @@ public class LowMexStyleGenerator extends StyleGenerator {
     protected WeightedOptionsWithFallback<PropGenerator> getPropGeneratorOptions() {
         return WeightedOptionsWithFallback.of(new BasicPropGenerator(),
                                               new WeightedOption<>(new BasicPropGenerator(), 1f),
-                                              new WeightedOption<>(new NavyWrecksPropGenerator(), 2f),
+                                              new WeightedOption<>(new BoulderFieldPropGenerator(), 1f),
                                               new WeightedOption<>(new EnemyCivPropGenerator(), .5f),
+                                              new WeightedOption<>(new HighReclaimPropGenerator(), .5f),
                                               new WeightedOption<>(new LargeBattlePropGenerator(), 2f),
+                                              new WeightedOption<>(new NavyWrecksPropGenerator(), 2f),
                                               new WeightedOption<>(new NeutralCivPropGenerator(), 1f),
                                               new WeightedOption<>(new RockFieldPropGenerator(), 1f),
-                                              new WeightedOption<>(new SmallBattlePropGenerator(), 1f),
-                                              new WeightedOption<>(new HighReclaimPropGenerator(), .5f));
+                                              new WeightedOption<>(new SmallBattlePropGenerator(), 1f));
     }
 }
 

--- a/generator/src/main/java/com/faforever/neroxis/generator/style/MountainRangeStyleGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/style/MountainRangeStyleGenerator.java
@@ -4,6 +4,7 @@ import com.faforever.neroxis.generator.ParameterConstraints;
 import com.faforever.neroxis.generator.WeightedOption;
 import com.faforever.neroxis.generator.WeightedOptionsWithFallback;
 import com.faforever.neroxis.generator.prop.BasicPropGenerator;
+import com.faforever.neroxis.generator.prop.BoulderFieldPropGenerator;
 import com.faforever.neroxis.generator.prop.EnemyCivPropGenerator;
 import com.faforever.neroxis.generator.prop.HighReclaimPropGenerator;
 import com.faforever.neroxis.generator.prop.LargeBattlePropGenerator;
@@ -32,11 +33,12 @@ public class MountainRangeStyleGenerator extends StyleGenerator {
     protected WeightedOptionsWithFallback<PropGenerator> getPropGeneratorOptions() {
         return WeightedOptionsWithFallback.of(new BasicPropGenerator(),
                                               new WeightedOption<>(new BasicPropGenerator(), 1f),
+                                              new WeightedOption<>(new BoulderFieldPropGenerator(), 1f),
                                               new WeightedOption<>(new EnemyCivPropGenerator(), .5f),
+                                              new WeightedOption<>(new HighReclaimPropGenerator(), .5f),
                                               new WeightedOption<>(new LargeBattlePropGenerator(), 2f),
                                               new WeightedOption<>(new NeutralCivPropGenerator(), 1f),
                                               new WeightedOption<>(new RockFieldPropGenerator(), 1f),
-                                              new WeightedOption<>(new SmallBattlePropGenerator(), 1f),
-                                              new WeightedOption<>(new HighReclaimPropGenerator(), .5f));
+                                              new WeightedOption<>(new SmallBattlePropGenerator(), 1f));
     }
 }

--- a/generator/src/main/java/com/faforever/neroxis/generator/style/OneIslandStyleGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/style/OneIslandStyleGenerator.java
@@ -4,6 +4,7 @@ import com.faforever.neroxis.generator.ParameterConstraints;
 import com.faforever.neroxis.generator.WeightedOption;
 import com.faforever.neroxis.generator.WeightedOptionsWithFallback;
 import com.faforever.neroxis.generator.prop.BasicPropGenerator;
+import com.faforever.neroxis.generator.prop.BoulderFieldPropGenerator;
 import com.faforever.neroxis.generator.prop.NavyWrecksPropGenerator;
 import com.faforever.neroxis.generator.prop.NeutralCivPropGenerator;
 import com.faforever.neroxis.generator.prop.PropGenerator;
@@ -30,6 +31,7 @@ public class OneIslandStyleGenerator extends StyleGenerator {
     protected WeightedOptionsWithFallback<PropGenerator> getPropGeneratorOptions() {
         return WeightedOptionsWithFallback.of(new BasicPropGenerator(),
                                               new WeightedOption<>(new BasicPropGenerator(), 1f),
+                                              new WeightedOption<>(new BoulderFieldPropGenerator(), 1f),
                                               new WeightedOption<>(new NavyWrecksPropGenerator(), 2f),
                                               new WeightedOption<>(new NeutralCivPropGenerator(), 1f),
                                               new WeightedOption<>(new RockFieldPropGenerator(), 1f),

--- a/generator/src/main/java/com/faforever/neroxis/generator/style/SmallIslandsStyleGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/style/SmallIslandsStyleGenerator.java
@@ -4,6 +4,7 @@ import com.faforever.neroxis.generator.ParameterConstraints;
 import com.faforever.neroxis.generator.WeightedOption;
 import com.faforever.neroxis.generator.WeightedOptionsWithFallback;
 import com.faforever.neroxis.generator.prop.BasicPropGenerator;
+import com.faforever.neroxis.generator.prop.BoulderFieldPropGenerator;
 import com.faforever.neroxis.generator.prop.NavyWrecksPropGenerator;
 import com.faforever.neroxis.generator.prop.PropGenerator;
 import com.faforever.neroxis.generator.prop.RockFieldPropGenerator;
@@ -29,6 +30,7 @@ public class SmallIslandsStyleGenerator extends StyleGenerator {
     protected WeightedOptionsWithFallback<PropGenerator> getPropGeneratorOptions() {
         return WeightedOptionsWithFallback.of(new BasicPropGenerator(),
                                               new WeightedOption<>(new BasicPropGenerator(), 1f),
+                                              new WeightedOption<>(new BoulderFieldPropGenerator(), 1f),
                                               new WeightedOption<>(new NavyWrecksPropGenerator(), 2f),
                                               new WeightedOption<>(new RockFieldPropGenerator(), 1f),
                                               new WeightedOption<>(new SmallBattlePropGenerator(), 1f));

--- a/generator/src/main/java/com/faforever/neroxis/generator/style/ValleyStyleGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/style/ValleyStyleGenerator.java
@@ -4,6 +4,7 @@ import com.faforever.neroxis.generator.ParameterConstraints;
 import com.faforever.neroxis.generator.WeightedOption;
 import com.faforever.neroxis.generator.WeightedOptionsWithFallback;
 import com.faforever.neroxis.generator.prop.BasicPropGenerator;
+import com.faforever.neroxis.generator.prop.BoulderFieldPropGenerator;
 import com.faforever.neroxis.generator.prop.EnemyCivPropGenerator;
 import com.faforever.neroxis.generator.prop.HighReclaimPropGenerator;
 import com.faforever.neroxis.generator.prop.LargeBattlePropGenerator;
@@ -32,12 +33,13 @@ public class ValleyStyleGenerator extends StyleGenerator {
     protected WeightedOptionsWithFallback<PropGenerator> getPropGeneratorOptions() {
         return WeightedOptionsWithFallback.of(new BasicPropGenerator(),
                                               new WeightedOption<>(new BasicPropGenerator(), 1f),
+                                              new WeightedOption<>(new BoulderFieldPropGenerator(), 1f),
                                               new WeightedOption<>(new EnemyCivPropGenerator(), .5f),
+                                              new WeightedOption<>(new HighReclaimPropGenerator(), .5f),
                                               new WeightedOption<>(new LargeBattlePropGenerator(), 2f),
                                               new WeightedOption<>(new NeutralCivPropGenerator(), 1f),
                                               new WeightedOption<>(new RockFieldPropGenerator(), 1f),
-                                              new WeightedOption<>(new SmallBattlePropGenerator(), 1f),
-                                              new WeightedOption<>(new HighReclaimPropGenerator(), .5f));
+                                              new WeightedOption<>(new SmallBattlePropGenerator(), 1f));
     }
 }
 

--- a/generator/src/test/java/com/faforever/neroxis/generator/MapGeneratorParsingTest.java
+++ b/generator/src/test/java/com/faforever/neroxis/generator/MapGeneratorParsingTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Execution(ExecutionMode.CONCURRENT)
 public class MapGeneratorParsingTest {
-    String mapName = "neroxis_map_generator_snapshot_aaaaaaaaaacne_aicaedyaaeaqc";
+    String mapName = "neroxis_map_generator_snapshot_aaaaaaaaaacne_aicaedyaaeaqe";
     long seed = 1234;
     byte spawnCount = 2;
     TerrainStyle terrainStyle = TerrainStyle.BIG_ISLANDS;

--- a/generator/src/test/java/com/faforever/neroxis/generator/MapGeneratorTest.java
+++ b/generator/src/test/java/com/faforever/neroxis/generator/MapGeneratorTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Execution(ExecutionMode.SAME_THREAD)
 public class MapGeneratorTest {
     public static final int NUM_DETERMINISM_REPEATS = 10;
-    String mapName = "neroxis_map_generator_snapshot_aaaaaaaaaacne_aicaedyaaeaqc";
+    String mapName = "neroxis_map_generator_snapshot_aaaaaaaaaacne_aicaedyaaeaqe";
     long seed = 1234;
     byte spawnCount = 2;
     TerrainStyle terrainStyle = TerrainStyle.BIG_ISLANDS;


### PR DESCRIPTION
Adds the changes to the HIGH_RECLAIM generator from #384 as a new prop generator.
![grafik](https://github.com/FAForever/Neroxis-Map-Generator/assets/52536103/e6cb47ac-3757-43f9-93d6-9b7b0f87013a)


It has rather high reclaim, but not as high as the HIGH_RECLAIM generator. We could add this as a second prop generator to the HIGH_RECLAIM map style or leave leave that style as is.