### PR TITLE
Odd symmetry fixes

### DIFF
--- a/generator/src/main/java/com/faforever/neroxis/generator/cli/BasicOptions.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/cli/BasicOptions.java
@@ -16,7 +16,7 @@ public class BasicOptions {
     private Long seed = new Random().nextLong();
     @CommandLine.Option(names = "--spawn-count", order = 5, defaultValue = "6", description = "Spawn count for the generated map", showDefaultValue = CommandLine.Help.Visibility.ALWAYS)
     private Integer spawnCount;
-    @CommandLine.Option(names = "--num-teams", order = 6, defaultValue = "3", description = "Number of teams for the generated map (0 is no teams asymmetric)", showDefaultValue = CommandLine.Help.Visibility.ALWAYS)
+    @CommandLine.Option(names = "--num-teams", order = 6, defaultValue = "2", description = "Number of teams for the generated map (0 is no teams asymmetric)", showDefaultValue = CommandLine.Help.Visibility.ALWAYS)
     private Integer numTeams;
     private Integer mapSize;
 

--- a/generator/src/main/java/com/faforever/neroxis/generator/cli/BasicOptions.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/cli/BasicOptions.java
@@ -16,7 +16,7 @@ public class BasicOptions {
     private Long seed = new Random().nextLong();
     @CommandLine.Option(names = "--spawn-count", order = 5, defaultValue = "6", description = "Spawn count for the generated map", showDefaultValue = CommandLine.Help.Visibility.ALWAYS)
     private Integer spawnCount;
-    @CommandLine.Option(names = "--num-teams", order = 6, defaultValue = "2", description = "Number of teams for the generated map (0 is no teams asymmetric)", showDefaultValue = CommandLine.Help.Visibility.ALWAYS)
+    @CommandLine.Option(names = "--num-teams", order = 6, defaultValue = "3", description = "Number of teams for the generated map (0 is no teams asymmetric)", showDefaultValue = CommandLine.Help.Visibility.ALWAYS)
     private Integer numTeams;
     private Integer mapSize;
 

--- a/generator/src/main/java/com/faforever/neroxis/generator/terrain/BasicTerrainGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/terrain/BasicTerrainGenerator.java
@@ -61,7 +61,7 @@ public class BasicTerrainGenerator extends TerrainGenerator {
         super.initialize(map, seed, generatorParameters, symmetrySettings);
         spawnLandMask = new BooleanMask(map.getSize() + 1, random.nextLong(), symmetrySettings, "spawnLandMask", true);
         spawnPlateauMask = new BooleanMask(map.getSize() + 1, random.nextLong(), symmetrySettings, "spawnPlateauMask",
-                true);
+                                           true);
         land = new BooleanMask(1, random.nextLong(), symmetrySettings, "land", true);
         mountains = new BooleanMask(1, random.nextLong(), symmetrySettings, "mountains", true);
         plateaus = new BooleanMask(1, random.nextLong(), symmetrySettings, "plateaus", true);
@@ -145,9 +145,9 @@ public class BasicTerrainGenerator extends TerrainGenerator {
         connections.setSize(map.getSize() + 1);
 
         MapMaskMethods.connectTeamsAroundCenter(map, random.nextLong(), connections, minMiddlePoints, maxMiddlePoints,
-                numTeamConnections, maxStepSize, 32);
+                                                numTeamConnections, maxStepSize, 32);
         MapMaskMethods.connectTeammates(map, random.nextLong(), connections, maxMiddlePoints, numTeammateConnections,
-                maxStepSize);
+                                        maxStepSize);
     }
 
     protected void landSetup() {
@@ -165,8 +165,8 @@ public class BasicTerrainGenerator extends TerrainGenerator {
             // so this is an alternative algorithn, which yields different but similar land generation
             FloatMask genland = new FloatMask(mapSize + 1, random.nextLong(), symmetrySettings, "landgen", true);
             genland.addPerlinNoise(100, 1f)
-                    .addPerlinNoise(25, 0.25f)
-                    .addPerlinNoise(10, -0.25f);
+                   .addPerlinNoise(25, 0.25f)
+                   .addPerlinNoise(10, -0.25f);
             var landGenBool = genland.copyAsBooleanMask(0.5f);
             landGenBool.invert();
             landGenBool.dilute(.5f, 10);
@@ -181,8 +181,8 @@ public class BasicTerrainGenerator extends TerrainGenerator {
             // Original Algorithm
             land.setSize(mapSize / 16);
             land.randomize(scaledLandDensity)
-                    .blur(2, .75f)
-                    .erode(.5f);
+                .blur(2, .75f)
+                .erode(.5f);
             land.setSize(mapSize / 4);
             land.dilute(.5f, mapSize / 128);
             land.setSize(mapSize + 1);
@@ -203,8 +203,8 @@ public class BasicTerrainGenerator extends TerrainGenerator {
             plateaus.setSize(map.getSize() + 1);
             FloatMask genplateaus = new FloatMask(map.getSize() + 1, random.nextLong(), symmetrySettings, "plateausgen", true);
             genplateaus.addPerlinNoise(50, 1f)
-                    .addPerlinNoise(25, 0.25f)
-                    .addPerlinNoise(10, -0.25f);
+                       .addPerlinNoise(25, 0.25f)
+                       .addPerlinNoise(10, -0.25f);
             var plateausGenBool = genplateaus.copyAsBooleanMask(0.75f);
             plateausGenBool.dilute(.5f, 10);
             plateaus.add(plateausGenBool);
@@ -260,11 +260,11 @@ public class BasicTerrainGenerator extends TerrainGenerator {
         if (map.getSize() > 512 && symmetrySettings.spawnSymmetry().getNumSymPoints() <= 4) {
             land.add(spawnLandMask).add(spawnPlateauMask).inflate(16).deflate(16).setSize(map.getSize() / 8);
             land.erode(.5f, 10)
-                    .add(spawnLandMask.copy().setSize(map.getSize() / 8))
-                    .add(spawnPlateauMask.copy().setSize(map.getSize() / 8))
-                    .blur(4, .75f)
-                    .dilute(.5f, 5)
-                    .setSize(map.getSize() + 1);
+                .add(spawnLandMask.copy().setSize(map.getSize() / 8))
+                .add(spawnPlateauMask.copy().setSize(map.getSize() / 8))
+                .blur(4, .75f)
+                .dilute(.5f, 5)
+                .setSize(map.getSize() + 1);
             land.blur(8, .75f);
         } else {
             land.dilute(.25f, 16).blur(2);
@@ -286,7 +286,7 @@ public class BasicTerrainGenerator extends TerrainGenerator {
     protected void enforceSymmetry() {
         SymmetrySettings symmetrySettings = heightmap.getSymmetrySettings();
         if (!symmetrySettings.terrainSymmetry().isPerfectSymmetry() && symmetrySettings.spawnSymmetry()
-                .isPerfectSymmetry()) {
+                                                                                       .isPerfectSymmetry()) {
             land.forceSymmetry();
             mountains.forceSymmetry();
             plateaus.forceSymmetry();
@@ -317,25 +317,25 @@ public class BasicTerrainGenerator extends TerrainGenerator {
         heightMapNoise.setSize(mapSize / 128);
 
         heightmapOcean.addDistance(land, -.45f)
-                .clampMin(oceanFloor)
-                .useBrushWithinAreaWithDensity(water.deflate(8).subtract(deepWater), brush, shallowWaterBrushSize,
-                        shallowWaterBrushDensity, shallowWaterBrushIntensity, false)
-                .useBrushWithinAreaWithDensity(deepWater, brush, deepWaterBrushSize, deepWaterBrushDensity,
-                        deepWaterBrushIntensity, false)
-                .clampMax(0f)
-                .blur(4, deepWater)
-                .blur(1);
+                      .clampMin(oceanFloor)
+                      .useBrushWithinAreaWithDensity(water.deflate(8).subtract(deepWater), brush, shallowWaterBrushSize,
+                                                     shallowWaterBrushDensity, shallowWaterBrushIntensity, false)
+                      .useBrushWithinAreaWithDensity(deepWater, brush, deepWaterBrushSize, deepWaterBrushDensity,
+                                                     deepWaterBrushIntensity, false)
+                      .clampMax(0f)
+                      .blur(4, deepWater)
+                      .blur(1);
 
         heightmapLand.add(heightmapHills)
-                .add(heightmapValleys)
-                .add(heightmapMountains)
-                .add(landHeight)
-                .add(heightmapPlateaus)
-                .setToValue(spawnLandMask, landHeight)
-                .setToValue(spawnPlateauMask, plateauHeight + landHeight)
-                .blur(1, spawnLandMask.copy().inflate(4))
-                .blur(1, spawnPlateauMask.copy().inflate(4))
-                .add(heightmapOcean);
+                     .add(heightmapValleys)
+                     .add(heightmapMountains)
+                     .add(landHeight)
+                     .add(heightmapPlateaus)
+                     .setToValue(spawnLandMask, landHeight)
+                     .setToValue(spawnPlateauMask, plateauHeight + landHeight)
+                     .blur(1, spawnLandMask.copy().inflate(4))
+                     .blur(1, spawnPlateauMask.copy().inflate(4))
+                     .add(heightmapOcean);
 
         heightmap.add(heightmapLand).add(waterHeight);
 
@@ -343,12 +343,12 @@ public class BasicTerrainGenerator extends TerrainGenerator {
             heightMapNoise.addWhiteNoise(plateauHeight / 3).resample(mapSize / 64);
             heightMapNoise.addWhiteNoise(plateauHeight / 3).resample(mapSize + 1);
             heightMapNoise.addWhiteNoise(1)
-                    .subtractAvg()
-                    .clampMin(0f)
-                    .setToValue(land.copy().invert().inflate(16), 0f)
-                    .blur(mapSize / 16, spawnLandMask.copy().inflate(8))
-                    .blur(mapSize / 16, spawnPlateauMask.copy().inflate(8))
-                    .blur(mapSize / 16);
+                          .subtractAvg()
+                          .clampMin(0f)
+                          .setToValue(land.copy().invert().inflate(16), 0f)
+                          .blur(mapSize / 16, spawnLandMask.copy().inflate(8))
+                          .blur(mapSize / 16, spawnPlateauMask.copy().inflate(8))
+                          .blur(mapSize / 16);
             heightmap.add(heightMapNoise);
         }
 
@@ -360,7 +360,7 @@ public class BasicTerrainGenerator extends TerrainGenerator {
 
         heightmapMountains.setSize(map.getSize() + 1);
         heightmapMountains.useBrushWithinAreaWithDensity(mountains, brush, mountainBrushSize, mountainBrushDensity,
-                mountainBrushIntensity, false);
+                                                         mountainBrushIntensity, false);
 
         BooleanMask paintedMountains = heightmapMountains.copyAsBooleanMask(plateauHeight / 2);
 
@@ -375,7 +375,7 @@ public class BasicTerrainGenerator extends TerrainGenerator {
 
         heightmapPlateaus.setSize(map.getSize() + 1);
         heightmapPlateaus.useBrushWithinAreaWithDensity(plateaus, brush, plateauBrushSize, plateauBrushDensity,
-                plateauBrushIntensity, false).clampMax(plateauHeight);
+                                                        plateauBrushIntensity, false).clampMax(plateauHeight);
 
         BooleanMask paintedPlateaus = heightmapPlateaus.copyAsBooleanMask(plateauHeight - 3);
 
@@ -402,20 +402,20 @@ public class BasicTerrainGenerator extends TerrainGenerator {
         valleys.setSize(map.getSize() / 4);
 
         hills.randomWalk(random.nextInt(4) + 1, random.nextInt(map.getSize() / 4) / numSymPoints)
-                .dilute(.5f, 2)
-                .setSize(map.getSize() + 1);
+             .dilute(.5f, 2)
+             .setSize(map.getSize() + 1);
         hills.multiply(land.copy().deflate(8)).subtract(plateaus.copy().outline().inflate(8)).subtract(spawnLandMask);
         valleys.randomWalk(random.nextInt(4), random.nextInt(map.getSize() / 4) / numSymPoints)
-                .dilute(.5f, 4)
-                .setSize(map.getSize() + 1);
+               .dilute(.5f, 4)
+               .setSize(map.getSize() + 1);
         valleys.multiply(plateaus.copy().deflate(8)).subtract(spawnPlateauMask);
 
         valleyBrushIntensity = -0.35f;
         heightmapValleys.useBrushWithinAreaWithDensity(valleys, brushValley, smallFeatureBrushSize, valleyBrushDensity,
-                valleyBrushIntensity, false).clampMin(valleyFloor);
+                                                       valleyBrushIntensity, false).clampMin(valleyFloor);
         heightmapHills.useBrushWithinAreaWithDensity(hills.add(mountains.copy().outline().inflate(4).acid(.01f, 4)),
-                brushHill, smallFeatureBrushSize, hillBrushDensity,
-                hillBrushIntensity, false);
+                                                     brushHill, smallFeatureBrushSize, hillBrushDensity,
+                                                     hillBrushIntensity, false);
     }
 
     protected void initRamps() {
@@ -427,33 +427,33 @@ public class BasicTerrainGenerator extends TerrainGenerator {
 
         if (map.getSize() >= 512) {
             MapMaskMethods.pathInEdgeBounds(random.nextLong(), ramps, maxStepSize, numPaths, maxMiddlePoints, bound,
-                    (float) (StrictMath.PI / 2));
+                                            (float) (StrictMath.PI / 2));
         } else {
             MapMaskMethods.pathInEdgeBounds(random.nextLong(), ramps, maxStepSize, numPaths / 4, maxMiddlePoints, bound,
-                    (float) (StrictMath.PI / 2));
+                                            (float) (StrictMath.PI / 2));
         }
 
         ramps.subtract(connections.copy().inflate(64))
-                .inflate(maxStepSize / 2f)
-                .add(connections.copy().inflate(maxStepSize / 2f))
-                .multiply(plateaus.copy().outline())
-                .subtract(mountains)
-                .inflate(10);
+             .inflate(maxStepSize / 2f)
+             .add(connections.copy().inflate(maxStepSize / 2f))
+             .multiply(plateaus.copy().outline())
+             .subtract(mountains)
+             .inflate(10);
     }
 
     private void blurRamps() {
         BooleanMask noRamps = plateaus.copy().outline().subtract(ramps).add(mountains);
         BooleanMask inflatedRamps = ramps.copy();
         heightmap.blur(48, inflatedRamps)
-                .blur(32, inflatedRamps.inflate(8).subtract(noRamps.inflate(4)))
-                .blur(4, inflatedRamps.copy().outline().inflate(4))
-                .blur(24, inflatedRamps.inflate(8).subtract(noRamps.inflate(4)))
-                .blur(4, inflatedRamps.copy().outline().inflate(4))
-                .blur(16, inflatedRamps.inflate(16).subtract(noRamps.inflate(4)))
-                .blur(4, inflatedRamps.copy().outline().inflate(4))
-                .blur(8, inflatedRamps.inflate(16).subtract(noRamps.inflate(4)))
-                .blur(4, inflatedRamps.copy().outline().inflate(4))
-                .clampMin(0f)
-                .clampMax(255f);
+                 .blur(32, inflatedRamps.inflate(8).subtract(noRamps.inflate(4)))
+                 .blur(4, inflatedRamps.copy().outline().inflate(4))
+                 .blur(24, inflatedRamps.inflate(8).subtract(noRamps.inflate(4)))
+                 .blur(4, inflatedRamps.copy().outline().inflate(4))
+                 .blur(16, inflatedRamps.inflate(16).subtract(noRamps.inflate(4)))
+                 .blur(4, inflatedRamps.copy().outline().inflate(4))
+                 .blur(8, inflatedRamps.inflate(16).subtract(noRamps.inflate(4)))
+                 .blur(4, inflatedRamps.copy().outline().inflate(4))
+                 .clampMin(0f)
+                 .clampMax(255f);
     }
 }

--- a/generator/src/main/java/com/faforever/neroxis/generator/terrain/BasicTerrainGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/terrain/BasicTerrainGenerator.java
@@ -4,6 +4,7 @@ import com.faforever.neroxis.brushes.Brushes;
 import com.faforever.neroxis.generator.GeneratorParameters;
 import com.faforever.neroxis.map.SCMap;
 import com.faforever.neroxis.map.SymmetrySettings;
+import com.faforever.neroxis.map.SymmetryType;
 import com.faforever.neroxis.mask.BooleanMask;
 import com.faforever.neroxis.mask.FloatMask;
 import com.faforever.neroxis.mask.MapMaskMethods;
@@ -60,7 +61,7 @@ public class BasicTerrainGenerator extends TerrainGenerator {
         super.initialize(map, seed, generatorParameters, symmetrySettings);
         spawnLandMask = new BooleanMask(map.getSize() + 1, random.nextLong(), symmetrySettings, "spawnLandMask", true);
         spawnPlateauMask = new BooleanMask(map.getSize() + 1, random.nextLong(), symmetrySettings, "spawnPlateauMask",
-                                           true);
+                true);
         land = new BooleanMask(1, random.nextLong(), symmetrySettings, "land", true);
         mountains = new BooleanMask(1, random.nextLong(), symmetrySettings, "mountains", true);
         plateaus = new BooleanMask(1, random.nextLong(), symmetrySettings, "plateaus", true);
@@ -144,9 +145,9 @@ public class BasicTerrainGenerator extends TerrainGenerator {
         connections.setSize(map.getSize() + 1);
 
         MapMaskMethods.connectTeamsAroundCenter(map, random.nextLong(), connections, minMiddlePoints, maxMiddlePoints,
-                                                numTeamConnections, maxStepSize, 32);
+                numTeamConnections, maxStepSize, 32);
         MapMaskMethods.connectTeammates(map, random.nextLong(), connections, maxMiddlePoints, numTeammateConnections,
-                                        maxStepSize);
+                maxStepSize);
     }
 
     protected void landSetup() {
@@ -156,13 +157,37 @@ public class BasicTerrainGenerator extends TerrainGenerator {
         float scaledLandDensity = landDensity * landDensityRange + landDensityMin;
         int mapSize = map.getSize();
 
-        land.setSize(mapSize / 16);
-
-        land.randomize(scaledLandDensity).blur(2, .75f).erode(.5f);
-        land.setSize(mapSize / 4);
-        land.dilute(.5f, mapSize / 128);
         land.setSize(mapSize + 1);
-        land.blur(8, .75f);
+
+        if (symmetrySettings.getSymmetry(SymmetryType.SPAWN).isOddSymmetry()) {
+            // The original algorithm runs into rounding errors when the symmetry is odd
+            // it's more pronounced because it starts with mapSize / 16
+            // so this is an alternative algorithn, which yields different but similar land generation
+            FloatMask genland = new FloatMask(mapSize + 1, random.nextLong(), symmetrySettings, "landgen", true);
+            genland.addPerlinNoise(100, 1f)
+                    .addPerlinNoise(25, 0.25f)
+                    .addPerlinNoise(10, -0.25f);
+            var landGenBool = genland.copyAsBooleanMask(0.5f);
+            landGenBool.invert();
+            landGenBool.dilute(.5f, 10);
+            if (mapSize < 512 || random.nextInt() % 3 > 0) {
+                // If the map size > 10k then there a 30% change to skip this dilute
+                // which will make it a navy map
+                landGenBool.dilute(.5f, 40);
+            }
+            landGenBool.blur(8, .75f);
+            land.add(landGenBool);
+        } else {
+            // Original Algorithm
+            land.setSize(mapSize / 16);
+            land.randomize(scaledLandDensity)
+                    .blur(2, .75f)
+                    .erode(.5f);
+            land.setSize(mapSize / 4);
+            land.dilute(.5f, mapSize / 128);
+            land.setSize(mapSize + 1);
+            land.blur(8, .75f);
+        }
 
         if (mapSize <= 512) {
             land.add(connections.copy().inflate(mountainBrushSize / 8f).blur(12, .125f));
@@ -174,12 +199,23 @@ public class BasicTerrainGenerator extends TerrainGenerator {
         float plateauDensityMin = .6f;
         float plateauDensityRange = plateauDensityMax - plateauDensityMin;
         float scaledPlateauDensity = plateauDensity * plateauDensityRange + plateauDensityMin;
-        plateaus.setSize(map.getSize() / 16);
+        if (symmetrySettings.getSymmetry(SymmetryType.SPAWN).isOddSymmetry()) {
+            plateaus.setSize(map.getSize() + 1);
+            FloatMask genplateaus = new FloatMask(map.getSize() + 1, random.nextLong(), symmetrySettings, "plateausgen", true);
+            genplateaus.addPerlinNoise(50, 1f)
+                    .addPerlinNoise(25, 0.25f)
+                    .addPerlinNoise(10, -0.25f);
+            var plateausGenBool = genplateaus.copyAsBooleanMask(0.75f);
+            plateausGenBool.dilute(.5f, 10);
+            plateaus.add(plateausGenBool);
+        } else {
+            plateaus.setSize(map.getSize() / 16);
 
-        plateaus.randomize(scaledPlateauDensity).blur(2, .75f).setSize(map.getSize() / 4);
-        plateaus.dilute(.5f, map.getSize() / 128);
-        plateaus.setSize(map.getSize() + 1);
-        plateaus.blur(16, .75f);
+            plateaus.randomize(scaledPlateauDensity).blur(2, .75f).setSize(map.getSize() / 4);
+            plateaus.dilute(.5f, map.getSize() / 128);
+            plateaus.setSize(map.getSize() + 1);
+            plateaus.blur(16, .75f);
+        }
     }
 
     protected void mountainSetup() {
@@ -224,11 +260,11 @@ public class BasicTerrainGenerator extends TerrainGenerator {
         if (map.getSize() > 512 && symmetrySettings.spawnSymmetry().getNumSymPoints() <= 4) {
             land.add(spawnLandMask).add(spawnPlateauMask).inflate(16).deflate(16).setSize(map.getSize() / 8);
             land.erode(.5f, 10)
-                .add(spawnLandMask.copy().setSize(map.getSize() / 8))
-                .add(spawnPlateauMask.copy().setSize(map.getSize() / 8))
-                .blur(4, .75f)
-                .dilute(.5f, 5)
-                .setSize(map.getSize() + 1);
+                    .add(spawnLandMask.copy().setSize(map.getSize() / 8))
+                    .add(spawnPlateauMask.copy().setSize(map.getSize() / 8))
+                    .blur(4, .75f)
+                    .dilute(.5f, 5)
+                    .setSize(map.getSize() + 1);
             land.blur(8, .75f);
         } else {
             land.dilute(.25f, 16).blur(2);
@@ -250,7 +286,7 @@ public class BasicTerrainGenerator extends TerrainGenerator {
     protected void enforceSymmetry() {
         SymmetrySettings symmetrySettings = heightmap.getSymmetrySettings();
         if (!symmetrySettings.terrainSymmetry().isPerfectSymmetry() && symmetrySettings.spawnSymmetry()
-                                                                                       .isPerfectSymmetry()) {
+                .isPerfectSymmetry()) {
             land.forceSymmetry();
             mountains.forceSymmetry();
             plateaus.forceSymmetry();
@@ -281,25 +317,25 @@ public class BasicTerrainGenerator extends TerrainGenerator {
         heightMapNoise.setSize(mapSize / 128);
 
         heightmapOcean.addDistance(land, -.45f)
-                      .clampMin(oceanFloor)
-                      .useBrushWithinAreaWithDensity(water.deflate(8).subtract(deepWater), brush, shallowWaterBrushSize,
-                                                     shallowWaterBrushDensity, shallowWaterBrushIntensity, false)
-                      .useBrushWithinAreaWithDensity(deepWater, brush, deepWaterBrushSize, deepWaterBrushDensity,
-                                                     deepWaterBrushIntensity, false)
-                      .clampMax(0f)
-                      .blur(4, deepWater)
-                      .blur(1);
+                .clampMin(oceanFloor)
+                .useBrushWithinAreaWithDensity(water.deflate(8).subtract(deepWater), brush, shallowWaterBrushSize,
+                        shallowWaterBrushDensity, shallowWaterBrushIntensity, false)
+                .useBrushWithinAreaWithDensity(deepWater, brush, deepWaterBrushSize, deepWaterBrushDensity,
+                        deepWaterBrushIntensity, false)
+                .clampMax(0f)
+                .blur(4, deepWater)
+                .blur(1);
 
         heightmapLand.add(heightmapHills)
-                     .add(heightmapValleys)
-                     .add(heightmapMountains)
-                     .add(landHeight)
-                     .add(heightmapPlateaus)
-                     .setToValue(spawnLandMask, landHeight)
-                     .setToValue(spawnPlateauMask, plateauHeight + landHeight)
-                     .blur(1, spawnLandMask.copy().inflate(4))
-                     .blur(1, spawnPlateauMask.copy().inflate(4))
-                     .add(heightmapOcean);
+                .add(heightmapValleys)
+                .add(heightmapMountains)
+                .add(landHeight)
+                .add(heightmapPlateaus)
+                .setToValue(spawnLandMask, landHeight)
+                .setToValue(spawnPlateauMask, plateauHeight + landHeight)
+                .blur(1, spawnLandMask.copy().inflate(4))
+                .blur(1, spawnPlateauMask.copy().inflate(4))
+                .add(heightmapOcean);
 
         heightmap.add(heightmapLand).add(waterHeight);
 
@@ -307,12 +343,12 @@ public class BasicTerrainGenerator extends TerrainGenerator {
             heightMapNoise.addWhiteNoise(plateauHeight / 3).resample(mapSize / 64);
             heightMapNoise.addWhiteNoise(plateauHeight / 3).resample(mapSize + 1);
             heightMapNoise.addWhiteNoise(1)
-                          .subtractAvg()
-                          .clampMin(0f)
-                          .setToValue(land.copy().invert().inflate(16), 0f)
-                          .blur(mapSize / 16, spawnLandMask.copy().inflate(8))
-                          .blur(mapSize / 16, spawnPlateauMask.copy().inflate(8))
-                          .blur(mapSize / 16);
+                    .subtractAvg()
+                    .clampMin(0f)
+                    .setToValue(land.copy().invert().inflate(16), 0f)
+                    .blur(mapSize / 16, spawnLandMask.copy().inflate(8))
+                    .blur(mapSize / 16, spawnPlateauMask.copy().inflate(8))
+                    .blur(mapSize / 16);
             heightmap.add(heightMapNoise);
         }
 
@@ -324,7 +360,7 @@ public class BasicTerrainGenerator extends TerrainGenerator {
 
         heightmapMountains.setSize(map.getSize() + 1);
         heightmapMountains.useBrushWithinAreaWithDensity(mountains, brush, mountainBrushSize, mountainBrushDensity,
-                                                         mountainBrushIntensity, false);
+                mountainBrushIntensity, false);
 
         BooleanMask paintedMountains = heightmapMountains.copyAsBooleanMask(plateauHeight / 2);
 
@@ -339,7 +375,7 @@ public class BasicTerrainGenerator extends TerrainGenerator {
 
         heightmapPlateaus.setSize(map.getSize() + 1);
         heightmapPlateaus.useBrushWithinAreaWithDensity(plateaus, brush, plateauBrushSize, plateauBrushDensity,
-                                                        plateauBrushIntensity, false).clampMax(plateauHeight);
+                plateauBrushIntensity, false).clampMax(plateauHeight);
 
         BooleanMask paintedPlateaus = heightmapPlateaus.copyAsBooleanMask(plateauHeight - 3);
 
@@ -366,20 +402,20 @@ public class BasicTerrainGenerator extends TerrainGenerator {
         valleys.setSize(map.getSize() / 4);
 
         hills.randomWalk(random.nextInt(4) + 1, random.nextInt(map.getSize() / 4) / numSymPoints)
-             .dilute(.5f, 2)
-             .setSize(map.getSize() + 1);
+                .dilute(.5f, 2)
+                .setSize(map.getSize() + 1);
         hills.multiply(land.copy().deflate(8)).subtract(plateaus.copy().outline().inflate(8)).subtract(spawnLandMask);
         valleys.randomWalk(random.nextInt(4), random.nextInt(map.getSize() / 4) / numSymPoints)
-               .dilute(.5f, 4)
-               .setSize(map.getSize() + 1);
+                .dilute(.5f, 4)
+                .setSize(map.getSize() + 1);
         valleys.multiply(plateaus.copy().deflate(8)).subtract(spawnPlateauMask);
 
         valleyBrushIntensity = -0.35f;
         heightmapValleys.useBrushWithinAreaWithDensity(valleys, brushValley, smallFeatureBrushSize, valleyBrushDensity,
-                                                       valleyBrushIntensity, false).clampMin(valleyFloor);
+                valleyBrushIntensity, false).clampMin(valleyFloor);
         heightmapHills.useBrushWithinAreaWithDensity(hills.add(mountains.copy().outline().inflate(4).acid(.01f, 4)),
-                                                     brushHill, smallFeatureBrushSize, hillBrushDensity,
-                                                     hillBrushIntensity, false);
+                brushHill, smallFeatureBrushSize, hillBrushDensity,
+                hillBrushIntensity, false);
     }
 
     protected void initRamps() {
@@ -391,33 +427,33 @@ public class BasicTerrainGenerator extends TerrainGenerator {
 
         if (map.getSize() >= 512) {
             MapMaskMethods.pathInEdgeBounds(random.nextLong(), ramps, maxStepSize, numPaths, maxMiddlePoints, bound,
-                                            (float) (StrictMath.PI / 2));
+                    (float) (StrictMath.PI / 2));
         } else {
             MapMaskMethods.pathInEdgeBounds(random.nextLong(), ramps, maxStepSize, numPaths / 4, maxMiddlePoints, bound,
-                                            (float) (StrictMath.PI / 2));
+                    (float) (StrictMath.PI / 2));
         }
 
         ramps.subtract(connections.copy().inflate(64))
-             .inflate(maxStepSize / 2f)
-             .add(connections.copy().inflate(maxStepSize / 2f))
-             .multiply(plateaus.copy().outline())
-             .subtract(mountains)
-             .inflate(10);
+                .inflate(maxStepSize / 2f)
+                .add(connections.copy().inflate(maxStepSize / 2f))
+                .multiply(plateaus.copy().outline())
+                .subtract(mountains)
+                .inflate(10);
     }
 
     private void blurRamps() {
         BooleanMask noRamps = plateaus.copy().outline().subtract(ramps).add(mountains);
         BooleanMask inflatedRamps = ramps.copy();
         heightmap.blur(48, inflatedRamps)
-                 .blur(32, inflatedRamps.inflate(8).subtract(noRamps.inflate(4)))
-                 .blur(4, inflatedRamps.copy().outline().inflate(4))
-                 .blur(24, inflatedRamps.inflate(8).subtract(noRamps.inflate(4)))
-                 .blur(4, inflatedRamps.copy().outline().inflate(4))
-                 .blur(16, inflatedRamps.inflate(16).subtract(noRamps.inflate(4)))
-                 .blur(4, inflatedRamps.copy().outline().inflate(4))
-                 .blur(8, inflatedRamps.inflate(16).subtract(noRamps.inflate(4)))
-                 .blur(4, inflatedRamps.copy().outline().inflate(4))
-                 .clampMin(0f)
-                 .clampMax(255f);
+                .blur(32, inflatedRamps.inflate(8).subtract(noRamps.inflate(4)))
+                .blur(4, inflatedRamps.copy().outline().inflate(4))
+                .blur(24, inflatedRamps.inflate(8).subtract(noRamps.inflate(4)))
+                .blur(4, inflatedRamps.copy().outline().inflate(4))
+                .blur(16, inflatedRamps.inflate(16).subtract(noRamps.inflate(4)))
+                .blur(4, inflatedRamps.copy().outline().inflate(4))
+                .blur(8, inflatedRamps.inflate(16).subtract(noRamps.inflate(4)))
+                .blur(4, inflatedRamps.copy().outline().inflate(4))
+                .clampMin(0f)
+                .clampMax(255f);
     }
 }

--- a/shared/src/main/java/com/faforever/neroxis/map/Symmetry.java
+++ b/shared/src/main/java/com/faforever/neroxis/map/Symmetry.java
@@ -31,4 +31,5 @@ public enum Symmetry {
 
     private final boolean perfectSymmetry;
     private final int numSymPoints;
+    public final boolean isOddSymmetry() { return !perfectSymmetry; }
 }

--- a/shared/src/main/java/com/faforever/neroxis/mask/BooleanMask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/BooleanMask.java
@@ -82,7 +82,7 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
         enqueue(dependencies -> {
             T source = (T) dependencies.get(0);
             apply((x, y) -> setPrimitive(x, y, source.valueAtGreaterThanEqualTo(x, y, minValue)
-                    && source.valueAtLessThanEqualTo(x, y, maxValue)));
+                                               && source.valueAtLessThanEqualTo(x, y, maxValue)));
         }, other);
     }
 
@@ -746,12 +746,12 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
                 Vector2 previousLoc = checkPoints.get(checkPoints.size() - 1);
                 float angle = (float) ((random.nextFloat() - .5f) * 2 * StrictMath.PI / 2f) + previousLoc.angleTo(end);
                 if (symmetrySettings.terrainSymmetry() == Symmetry.POINT4
-                        && angle % (StrictMath.PI / 2) < StrictMath.PI / 8) {
+                    && angle % (StrictMath.PI / 2) < StrictMath.PI / 8) {
                     angle += (random.nextBoolean() ? -1 : 1) * (random.nextFloat() * .5f + .5f) * 2f * StrictMath.PI
-                            / 4f;
+                             / 4f;
                 }
                 float magnitude = random.nextFloat() * (midPointMaxDistance - midPointMinDistance)
-                        + midPointMinDistance;
+                                  + midPointMinDistance;
                 Vector2 nextLoc = new Vector2(previousLoc).addPolar(angle, magnitude);
                 checkPoints.add(nextLoc);
             }
@@ -770,8 +770,8 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
                     }
                     float magnitude = StrictMath.max(1, random.nextFloat() * maxStepSize);
                     float angle = oldAngle * .5f
-                            + location.angleTo(nextLoc) * .5f
-                            + (random.nextFloat() - .5f) * 2f * maxAngleError;
+                                  + location.angleTo(nextLoc) * .5f
+                                  + (random.nextFloat() - .5f) * 2f * maxAngleError;
                     location.addPolar(angle, magnitude).round();
                     oldAngle = angle;
                     numSteps++;
@@ -927,8 +927,8 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
             for (int y2 = minY; y2 < maxY; ++y2) {
                 int bitIndex = bitIndex(x2, y2, getSize());
                 if (inBounds(x2, y2)
-                        && getBit(bitIndex, maskCopy) != value
-                        && (x - x2) * (x - x2) + (y - y2) * (y - y2) <= radius2) {
+                    && getBit(bitIndex, maskCopy) != value
+                    && (x - x2) * (x - x2) + (y - y2) * (y - y2) <= radius2) {
                     setBit(bitIndex, value, maskCopy);
                 }
             }
@@ -1007,10 +1007,10 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
         return ((x > 0 && getPrimitive(x - 1, y) != value)
                 || (y > 0 && getPrimitive(x, y - 1) != value)
                 || (x
-                < size - 1
-                && getPrimitive(x
-                                        + 1, y)
-                != value)
+                    < size - 1
+                    && getPrimitive(x
+                                    + 1, y)
+                       != value)
                 || (y < size - 1 && getPrimitive(x, y + 1) != value));
     }
 
@@ -1152,9 +1152,9 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
         int maxXBound = getMaxXBound(symmetryType);
         return apply((x, y) -> {
             setPrimitive(x, y, getPrimitive(x, y) && !(x < minXBound
-                    || x >= maxXBound
-                    || y < getMinYBound(x, symmetryType)
-                    || y >= getMaxYBound(x, symmetryType)));
+                                                       || x >= maxXBound
+                                                       || y < getMinYBound(x, symmetryType)
+                                                       || y >= getMaxYBound(x, symmetryType)));
         });
     }
 

--- a/shared/src/main/java/com/faforever/neroxis/mask/BooleanMask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/BooleanMask.java
@@ -82,7 +82,7 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
         enqueue(dependencies -> {
             T source = (T) dependencies.get(0);
             apply((x, y) -> setPrimitive(x, y, source.valueAtGreaterThanEqualTo(x, y, minValue)
-                                               && source.valueAtLessThanEqualTo(x, y, maxValue)));
+                    && source.valueAtLessThanEqualTo(x, y, maxValue)));
         }, other);
     }
 
@@ -229,11 +229,31 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
             } else if (oldSize != newSize) {
                 long[] oldMask = mask;
                 initializeMask(newSize);
+
+                hasSet = new boolean[newSize][newSize];
+                for (int i = 0; i < newSize; i++) {
+                    for (int j = 0; j < newSize; j++) {
+                        hasSet[i][j] = false;
+                    }
+                }
+
                 Map<Integer, Integer> coordinateMap = getSymmetricScalingCoordinateMap(oldSize, newSize);
-                applyWithSymmetry(SymmetryType.SPAWN, (x, y) -> {
-                    boolean value = getBit(coordinateMap.get(x), coordinateMap.get(y), oldSize, oldMask);
-                    applyAtSymmetryPoints(x, y, SymmetryType.SPAWN, (sx, sy) -> setPrimitive(sx, sy, value));
-                });
+
+                if (symmetrySettings.getSymmetry(SymmetryType.SPAWN).isOddSymmetry()) {
+                    apply((x, y) -> {
+                        hasSet[x][y] = true;
+                        setPrimitive(x, y,
+                                getBit(coordinateMap.get(x), coordinateMap.get(y), oldSize, oldMask));
+                    });
+                } else {
+                    applyWithSymmetry(SymmetryType.SPAWN, (x, y) -> {
+                        boolean value = getBit(coordinateMap.get(x), coordinateMap.get(y), oldSize, oldMask);
+                        applyAtSymmetryPoints(x, y, SymmetryType.SPAWN, (sx, sy) -> {
+                            setPrimitive(sx, sy, value);
+                        });
+                    });
+                }
+
             }
         });
     }
@@ -261,7 +281,7 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
     public BooleanMask blur(int radius, float density) {
         int[][] innerCount = getInnerCount();
         return apply((x, y) -> setPrimitive(x, y, transformAverage(calculateAreaAverageAsInts(radius, x, y, innerCount),
-                                                                   density)));
+                density)));
     }
 
     @Override
@@ -390,7 +410,7 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
         return enqueue(dependencies -> {
             BooleanMask source = (BooleanMask) dependencies.get(0);
             applyWithOffset(source, (BiIntBooleanConsumer) this::subtractPrimitiveAt, xOffset, yOffset, center,
-                            wrapEdges);
+                    wrapEdges);
         }, other);
     }
 
@@ -444,7 +464,7 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
         return enqueue(dependencies -> {
             BooleanMask source = (BooleanMask) dependencies.get(0);
             applyWithOffset(source, (BiIntBooleanConsumer) this::multiplyPrimitiveAt, xOffset, yOffset, center,
-                            wrapEdges);
+                    wrapEdges);
         }, other);
     }
 
@@ -498,7 +518,7 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
         return enqueue(dependencies -> {
             BooleanMask source = (BooleanMask) dependencies.get(0);
             applyWithOffset(source, (BiIntBooleanConsumer) this::dividePrimitiveAt, xOffset, yOffset, center,
-                            wrapEdges);
+                    wrapEdges);
         }, other);
     }
 
@@ -690,7 +710,7 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
             Vector2 location = checkPoints.get(i);
             Vector2 nextLoc = checkPoints.get(i + 1);
             BezierCurve bezierCurve = new BezierCurve(random.nextInt(maxOrder - minOrder) + minOrder,
-                                                      random.nextLong());
+                    random.nextLong());
             bezierCurve.transformTo(location, nextLoc);
             List<Vector2> points = new ArrayList<>();
             for (float j = 0; j <= 1; j += 1f / size) {
@@ -706,11 +726,11 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
                                SymmetryType symmetryType) {
         return enqueue(() -> {
             path(start, end, maxStepSize, numMiddlePoints, midPointMaxDistance, midPointMinDistance, maxAngleError,
-                 symmetryType);
+                    symmetryType);
             if (symmetrySettings.getSymmetry(symmetryType).getNumSymPoints() > 1) {
                 List<Vector2> symmetryPoints = getSymmetryPointsWithOutOfBounds(end, symmetryType);
                 path(start, symmetryPoints.get(0), maxStepSize, numMiddlePoints, midPointMaxDistance,
-                     midPointMinDistance, maxAngleError, symmetryType);
+                        midPointMinDistance, maxAngleError, symmetryType);
             }
         });
     }
@@ -726,12 +746,12 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
                 Vector2 previousLoc = checkPoints.get(checkPoints.size() - 1);
                 float angle = (float) ((random.nextFloat() - .5f) * 2 * StrictMath.PI / 2f) + previousLoc.angleTo(end);
                 if (symmetrySettings.terrainSymmetry() == Symmetry.POINT4
-                    && angle % (StrictMath.PI / 2) < StrictMath.PI / 8) {
+                        && angle % (StrictMath.PI / 2) < StrictMath.PI / 8) {
                     angle += (random.nextBoolean() ? -1 : 1) * (random.nextFloat() * .5f + .5f) * 2f * StrictMath.PI
-                             / 4f;
+                            / 4f;
                 }
                 float magnitude = random.nextFloat() * (midPointMaxDistance - midPointMinDistance)
-                                  + midPointMinDistance;
+                        + midPointMinDistance;
                 Vector2 nextLoc = new Vector2(previousLoc).addPolar(angle, magnitude);
                 checkPoints.add(nextLoc);
             }
@@ -746,12 +766,12 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
                     List<Vector2> symmetryPoints = getSymmetryPoints(location, symmetryType);
                     if (inBounds(location) && symmetryPoints.stream().allMatch(this::inBounds)) {
                         applyAtSymmetryPoints((int) location.getX(), (int) location.getY(), SymmetryType.TERRAIN,
-                                              (sx, sy) -> setPrimitive(sx, sy, true));
+                                (sx, sy) -> setPrimitive(sx, sy, true));
                     }
                     float magnitude = StrictMath.max(1, random.nextFloat() * maxStepSize);
                     float angle = oldAngle * .5f
-                                  + location.angleTo(nextLoc) * .5f
-                                  + (random.nextFloat() - .5f) * 2f * maxAngleError;
+                            + location.angleTo(nextLoc) * .5f
+                            + (random.nextFloat() - .5f) * 2f * maxAngleError;
                     location.addPolar(angle, magnitude).round();
                     oldAngle = angle;
                     numSteps++;
@@ -909,7 +929,7 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
                 if (inBounds(x2, y2)
                     && getBit(bitIndex, maskCopy) != value
                     && (x - x2) * (x - x2) + (y - y2) * (y - y2) <= radius2) {
-                    setBit(bitIndex, value, maskCopy);
+                        setBit(bitIndex, value, maskCopy);
                 }
             }
         }
@@ -987,10 +1007,10 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
         return ((x > 0 && getPrimitive(x - 1, y) != value)
                 || (y > 0 && getPrimitive(x, y - 1) != value)
                 || (x
-                    < size - 1
-                    && getPrimitive(x
-                                    + 1, y)
-                       != value)
+                < size - 1
+                && getPrimitive(x
+                + 1, y)
+                != value)
                 || (y < size - 1 && getPrimitive(x, y + 1) != value));
     }
 
@@ -1008,11 +1028,21 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
             int size = getSize();
             for (int i = 0; i < count; i++) {
                 long[] maskCopy = getMaskCopy();
-                applyWithSymmetry(symmetryType, (x, y) -> {
-                    if (!getPrimitive(x, y) && random.nextFloat() < strength && isEdge(x, y)) {
-                        applyAtSymmetryPoints(x, y, symmetryType, (sx, sy) -> setBit(sx, sy, true, size, maskCopy));
-                    }
-                });
+
+                if (symmetrySettings.getSymmetry(SymmetryType.SPAWN).isOddSymmetry()) {
+                    apply((x, y) -> {
+                        if (!getPrimitive(x, y) && random.nextFloat() < strength && isEdge(x, y)) {
+                            setBit(x, y, true, size, maskCopy);
+                        }
+                    });
+                } else {
+                    applyWithSymmetry(symmetryType, (x, y) -> {
+                        if (!getPrimitive(x, y) && random.nextFloat() < strength && isEdge(x, y)) {
+                            applyAtSymmetryPoints(x, y, symmetryType, (sx, sy) -> setBit(sx, sy, true, size, maskCopy));
+                        }
+                    });
+                }
+
                 mask = maskCopy;
             }
         });
@@ -1030,11 +1060,19 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
             int size = getSize();
             for (int i = 0; i < count; i++) {
                 long[] maskCopy = getMaskCopy();
-                applyWithSymmetry(symmetryType, (x, y) -> {
-                    if (getPrimitive(x, y) && random.nextFloat() < strength && isEdge(x, y)) {
-                        applyAtSymmetryPoints(x, y, symmetryType, (sx, sy) -> setBit(sx, sy, false, size, maskCopy));
-                    }
-                });
+                if (symmetrySettings.getSymmetry(SymmetryType.SPAWN).isOddSymmetry()) {
+                    apply((x, y) -> {
+                        if (getPrimitive(x, y) && random.nextFloat() < strength && isEdge(x, y)) {
+                            setBit(x, y, false, size, maskCopy);
+                        }
+                    });
+                } else {
+                    applyWithSymmetry(symmetryType, (x, y) -> {
+                        if (getPrimitive(x, y) && random.nextFloat() < strength && isEdge(x, y)) {
+                            applyAtSymmetryPoints(x, y, symmetryType, (sx, sy) -> setBit(sx, sy, false, size, maskCopy));
+                        }
+                    });
+                }
                 mask = maskCopy;
             }
         });
@@ -1114,9 +1152,9 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
         int maxXBound = getMaxXBound(symmetryType);
         return apply((x, y) -> {
             setPrimitive(x, y, getPrimitive(x, y) && !(x < minXBound
-                                                       || x >= maxXBound
-                                                       || y < getMinYBound(x, symmetryType)
-                                                       || y >= getMaxYBound(x, symmetryType)));
+                    || x >= maxXBound
+                    || y < getMinYBound(x, symmetryType)
+                    || y >= getMaxYBound(x, symmetryType)));
         });
     }
 
@@ -1128,7 +1166,7 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
     public BooleanMask limitToCenteredCircle(float circleRadius) {
         int size = getSize();
         BooleanMask symmetryLimit = new BooleanMask(size, null, symmetrySettings, getName() + "symmetryLimit",
-                                                    isParallel());
+                isParallel());
         symmetryLimit.fillCircle(size / 2f, size / 2f, circleRadius, true);
         return multiply(symmetryLimit);
     }
@@ -1169,17 +1207,32 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
     public BooleanMask removeAreasSmallerThan(int maxArea) {
         int size = getSize();
         Set<Vector2> seen = new HashSet<>(size * size, 1f);
-        return applyWithSymmetry(SymmetryType.SPAWN, (x, y) -> {
-            Vector2 location = new Vector2(x, y);
-            if (!seen.contains(location)) {
-                boolean value = getPrimitive(location);
-                Set<Vector2> coordinates = getShapeCoordinates(location, maxArea);
-                seen.addAll(coordinates);
-                if (coordinates.size() < maxArea) {
-                    fillCoordinates(coordinates, !value);
+
+        if (symmetrySettings.getSymmetry(SymmetryType.SPAWN).isOddSymmetry()) {
+            return apply((x, y) -> {
+                Vector2 location = new Vector2(x, y);
+                if (!seen.contains(location)) {
+                    boolean value = getPrimitive(location);
+                    Set<Vector2> coordinates = getShapeCoordinates(location, maxArea);
+                    seen.addAll(coordinates);
+                    if (coordinates.size() < maxArea) {
+                        fillCoordinatesWithoutSym(coordinates, !value);
+                    }
                 }
-            }
-        });
+            });
+        } else {
+            return applyWithSymmetry(SymmetryType.SPAWN, (x, y) -> {
+                Vector2 location = new Vector2(x, y);
+                if (!seen.contains(location)) {
+                    boolean value = getPrimitive(location);
+                    Set<Vector2> coordinates = getShapeCoordinates(location, maxArea);
+                    seen.addAll(coordinates);
+                    if (coordinates.size() < maxArea) {
+                        fillCoordinates(coordinates, !value);
+                    }
+                }
+            });
+        }
     }
 
     /**
@@ -1443,24 +1496,24 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
             if (smallerSize == otherSize) {
                 if (symmetrySettings.spawnSymmetry().isPerfectSymmetry()) {
                     Map<Integer, Integer> coordinateXMap = getShiftedCoordinateMap(xOffset, center, wrapEdges,
-                                                                                   otherSize, size);
+                            otherSize, size);
                     Map<Integer, Integer> coordinateYMap = getShiftedCoordinateMap(yOffset, center, wrapEdges,
-                                                                                   otherSize, size);
+                            otherSize, size);
                     other.apply((x, y) -> {
                         int shiftX = coordinateXMap.get(x);
                         int shiftY = coordinateYMap.get(y);
                         if (inBounds(shiftX, shiftY)) {
                             boolean value = other.getPrimitive(x, y);
                             applyAtSymmetryPoints(shiftX, shiftY, SymmetryType.SPAWN,
-                                                  (sx, sy) -> action.accept(sx, sy, value));
+                                    (sx, sy) -> action.accept(sx, sy, value));
                         }
                     });
                 } else {
                     applyAtSymmetryPointsWithOutOfBounds(xOffset, yOffset, SymmetryType.SPAWN, (sx, sy) -> {
                         Map<Integer, Integer> coordinateXMap = getShiftedCoordinateMap(sx, center, wrapEdges, otherSize,
-                                                                                       size);
+                                size);
                         Map<Integer, Integer> coordinateYMap = getShiftedCoordinateMap(sy, center, wrapEdges, otherSize,
-                                                                                       size);
+                                size);
                         other.apply((x, y) -> {
                             int shiftX = coordinateXMap.get(x);
                             int shiftY = coordinateYMap.get(y);
@@ -1472,9 +1525,9 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
                 }
             } else {
                 Map<Integer, Integer> coordinateXMap = getShiftedCoordinateMap(xOffset, center, wrapEdges, size,
-                                                                               otherSize);
+                        otherSize);
                 Map<Integer, Integer> coordinateYMap = getShiftedCoordinateMap(yOffset, center, wrapEdges, size,
-                                                                               otherSize);
+                        otherSize);
                 apply((x, y) -> {
                     int shiftX = coordinateXMap.get(x);
                     int shiftY = coordinateYMap.get(y);

--- a/shared/src/main/java/com/faforever/neroxis/mask/BooleanMask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/BooleanMask.java
@@ -243,7 +243,7 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
                     apply((x, y) -> {
                         hasSet[x][y] = true;
                         setPrimitive(x, y,
-                                getBit(coordinateMap.get(x), coordinateMap.get(y), oldSize, oldMask));
+                                     getBit(coordinateMap.get(x), coordinateMap.get(y), oldSize, oldMask));
                     });
                 } else {
                     applyWithSymmetry(SymmetryType.SPAWN, (x, y) -> {
@@ -281,7 +281,7 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
     public BooleanMask blur(int radius, float density) {
         int[][] innerCount = getInnerCount();
         return apply((x, y) -> setPrimitive(x, y, transformAverage(calculateAreaAverageAsInts(radius, x, y, innerCount),
-                density)));
+                                                                   density)));
     }
 
     @Override
@@ -410,7 +410,7 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
         return enqueue(dependencies -> {
             BooleanMask source = (BooleanMask) dependencies.get(0);
             applyWithOffset(source, (BiIntBooleanConsumer) this::subtractPrimitiveAt, xOffset, yOffset, center,
-                    wrapEdges);
+                            wrapEdges);
         }, other);
     }
 
@@ -464,7 +464,7 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
         return enqueue(dependencies -> {
             BooleanMask source = (BooleanMask) dependencies.get(0);
             applyWithOffset(source, (BiIntBooleanConsumer) this::multiplyPrimitiveAt, xOffset, yOffset, center,
-                    wrapEdges);
+                            wrapEdges);
         }, other);
     }
 
@@ -518,7 +518,7 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
         return enqueue(dependencies -> {
             BooleanMask source = (BooleanMask) dependencies.get(0);
             applyWithOffset(source, (BiIntBooleanConsumer) this::dividePrimitiveAt, xOffset, yOffset, center,
-                    wrapEdges);
+                            wrapEdges);
         }, other);
     }
 
@@ -710,7 +710,7 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
             Vector2 location = checkPoints.get(i);
             Vector2 nextLoc = checkPoints.get(i + 1);
             BezierCurve bezierCurve = new BezierCurve(random.nextInt(maxOrder - minOrder) + minOrder,
-                    random.nextLong());
+                                                      random.nextLong());
             bezierCurve.transformTo(location, nextLoc);
             List<Vector2> points = new ArrayList<>();
             for (float j = 0; j <= 1; j += 1f / size) {
@@ -726,11 +726,11 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
                                SymmetryType symmetryType) {
         return enqueue(() -> {
             path(start, end, maxStepSize, numMiddlePoints, midPointMaxDistance, midPointMinDistance, maxAngleError,
-                    symmetryType);
+                 symmetryType);
             if (symmetrySettings.getSymmetry(symmetryType).getNumSymPoints() > 1) {
                 List<Vector2> symmetryPoints = getSymmetryPointsWithOutOfBounds(end, symmetryType);
                 path(start, symmetryPoints.get(0), maxStepSize, numMiddlePoints, midPointMaxDistance,
-                        midPointMinDistance, maxAngleError, symmetryType);
+                     midPointMinDistance, maxAngleError, symmetryType);
             }
         });
     }
@@ -766,7 +766,7 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
                     List<Vector2> symmetryPoints = getSymmetryPoints(location, symmetryType);
                     if (inBounds(location) && symmetryPoints.stream().allMatch(this::inBounds)) {
                         applyAtSymmetryPoints((int) location.getX(), (int) location.getY(), SymmetryType.TERRAIN,
-                                (sx, sy) -> setPrimitive(sx, sy, true));
+                                              (sx, sy) -> setPrimitive(sx, sy, true));
                     }
                     float magnitude = StrictMath.max(1, random.nextFloat() * maxStepSize);
                     float angle = oldAngle * .5f
@@ -927,9 +927,9 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
             for (int y2 = minY; y2 < maxY; ++y2) {
                 int bitIndex = bitIndex(x2, y2, getSize());
                 if (inBounds(x2, y2)
-                    && getBit(bitIndex, maskCopy) != value
-                    && (x - x2) * (x - x2) + (y - y2) * (y - y2) <= radius2) {
-                        setBit(bitIndex, value, maskCopy);
+                        && getBit(bitIndex, maskCopy) != value
+                        && (x - x2) * (x - x2) + (y - y2) * (y - y2) <= radius2) {
+                    setBit(bitIndex, value, maskCopy);
                 }
             }
         }
@@ -1009,7 +1009,7 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
                 || (x
                 < size - 1
                 && getPrimitive(x
-                + 1, y)
+                                        + 1, y)
                 != value)
                 || (y < size - 1 && getPrimitive(x, y + 1) != value));
     }
@@ -1166,7 +1166,7 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
     public BooleanMask limitToCenteredCircle(float circleRadius) {
         int size = getSize();
         BooleanMask symmetryLimit = new BooleanMask(size, null, symmetrySettings, getName() + "symmetryLimit",
-                isParallel());
+                                                    isParallel());
         symmetryLimit.fillCircle(size / 2f, size / 2f, circleRadius, true);
         return multiply(symmetryLimit);
     }
@@ -1496,24 +1496,24 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
             if (smallerSize == otherSize) {
                 if (symmetrySettings.spawnSymmetry().isPerfectSymmetry()) {
                     Map<Integer, Integer> coordinateXMap = getShiftedCoordinateMap(xOffset, center, wrapEdges,
-                            otherSize, size);
+                                                                                   otherSize, size);
                     Map<Integer, Integer> coordinateYMap = getShiftedCoordinateMap(yOffset, center, wrapEdges,
-                            otherSize, size);
+                                                                                   otherSize, size);
                     other.apply((x, y) -> {
                         int shiftX = coordinateXMap.get(x);
                         int shiftY = coordinateYMap.get(y);
                         if (inBounds(shiftX, shiftY)) {
                             boolean value = other.getPrimitive(x, y);
                             applyAtSymmetryPoints(shiftX, shiftY, SymmetryType.SPAWN,
-                                    (sx, sy) -> action.accept(sx, sy, value));
+                                                  (sx, sy) -> action.accept(sx, sy, value));
                         }
                     });
                 } else {
                     applyAtSymmetryPointsWithOutOfBounds(xOffset, yOffset, SymmetryType.SPAWN, (sx, sy) -> {
                         Map<Integer, Integer> coordinateXMap = getShiftedCoordinateMap(sx, center, wrapEdges, otherSize,
-                                size);
+                                                                                       size);
                         Map<Integer, Integer> coordinateYMap = getShiftedCoordinateMap(sy, center, wrapEdges, otherSize,
-                                size);
+                                                                                       size);
                         other.apply((x, y) -> {
                             int shiftX = coordinateXMap.get(x);
                             int shiftY = coordinateYMap.get(y);
@@ -1525,9 +1525,9 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
                 }
             } else {
                 Map<Integer, Integer> coordinateXMap = getShiftedCoordinateMap(xOffset, center, wrapEdges, size,
-                        otherSize);
+                                                                               otherSize);
                 Map<Integer, Integer> coordinateYMap = getShiftedCoordinateMap(yOffset, center, wrapEdges, size,
-                        otherSize);
+                                                                               otherSize);
                 apply((x, y) -> {
                     int shiftX = coordinateXMap.get(x);
                     int shiftY = coordinateYMap.get(y);

--- a/shared/src/main/java/com/faforever/neroxis/mask/FloatMask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/FloatMask.java
@@ -145,9 +145,9 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
         int gradientSize = size / resolution;
         float gradientScale = (float) size / gradientSize;
         Vector2Mask gradientVectors = new Vector2Mask(gradientSize +
-                1, random.nextLong(), new SymmetrySettings(Symmetry.NONE),
-                getName() +
-                        "PerlinVectors", isParallel());
+                                                              1, random.nextLong(), new SymmetrySettings(Symmetry.NONE),
+                                                      getName() +
+                                                              "PerlinVectors", isParallel());
         gradientVectors.randomize(-1f, 1f).normalize();
         FloatMask noise = new FloatMask(size, null, symmetrySettings, getName() + "PerlinNoise", isParallel());
         noise.enqueue(dependencies -> {
@@ -176,7 +176,7 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
                 float bottomLeft = new Vector2(dXHigh, dYLow).dot(source.get(xHigh, yLow));
                 float bottomRight = new Vector2(dXHigh, dYHigh).dot(source.get(xHigh, yHigh));
                 return MathUtil.smootherStep(MathUtil.smootherStep(topLeft, bottomLeft, dXLow),
-                        MathUtil.smootherStep(topRight, bottomRight, dXLow), dYLow);
+                                             MathUtil.smootherStep(topRight, bottomRight, dXLow), dYLow);
             });
             float noiseMin = noise.getMin();
             float noiseMax = noise.getMax();
@@ -225,17 +225,17 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
     @Override
     public Float getMin() {
         return (float) Arrays.stream(mask)
-                .flatMapToDouble(row -> IntStream.range(0, row.length).mapToDouble(i -> row[i]))
-                .min()
-                .orElseThrow(() -> new IllegalStateException("Empty Mask"));
+                             .flatMapToDouble(row -> IntStream.range(0, row.length).mapToDouble(i -> row[i]))
+                             .min()
+                             .orElseThrow(() -> new IllegalStateException("Empty Mask"));
     }
 
     @Override
     public Float getMax() {
         return (float) Arrays.stream(mask)
-                .flatMapToDouble(row -> IntStream.range(0, row.length).mapToDouble(i -> row[i]))
-                .max()
-                .orElseThrow(() -> new IllegalStateException("Empty Mask"));
+                             .flatMapToDouble(row -> IntStream.range(0, row.length).mapToDouble(i -> row[i]))
+                             .max()
+                             .orElseThrow(() -> new IllegalStateException("Empty Mask"));
     }
 
     public float getPrimitive(int x, int y) {
@@ -313,7 +313,7 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
         int size = getSize();
         for (int i = 0; i < numDrops; ++i) {
             waterDrop(maxIterations, random.nextInt(size), random.nextInt(size), friction, speed, erosionRate,
-                    depositionRate, maxOffset, iterationScale);
+                      depositionRate, maxOffset, iterationScale);
         }
         return forceSymmetry(SymmetryType.SPAWN);
     }
@@ -374,9 +374,9 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
 
     public FloatMask removeAreasOutsideRangeAndSize(int minSize, int maxSize, float minValue, float maxValue) {
         FloatMask areasToRemove = copy().copyAsBooleanMask(minValue, maxValue)
-                .removeAreasOutsideSizeRange(minSize, maxSize)
-                .invert()
-                .copyAsFloatMask(0f, 1f);
+                                        .removeAreasOutsideSizeRange(minSize, maxSize)
+                                        .invert()
+                                        .copyAsFloatMask(0f, 1f);
         return subtract(areasToRemove).clampMin(0f);
     }
 
@@ -475,8 +475,8 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
         float angle = (float) ((lightDirection.getAzimuth() - StrictMath.PI) % (StrictMath.PI * 2));
         float slope = (float) StrictMath.tan(lightDirection.getElevation());
         BooleanMask shadowMask = new BooleanMask(getSize(), getNextSeed(), new SymmetrySettings(Symmetry.NONE),
-                getName() +
-                        "Shadow", isParallel());
+                                                 getName() +
+                                                         "Shadow", isParallel());
         return shadowMask.enqueue(dependencies -> shadowMask.apply((x, y) -> {
             FloatMask source = (FloatMask) dependencies.get(0);
             Vector2 location = new Vector2(x, y);
@@ -782,8 +782,8 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
     @Override
     public Float getSum() {
         return (float) Arrays.stream(mask)
-                .flatMapToDouble(row -> IntStream.range(0, row.length).mapToDouble(i -> row[i]))
-                .sum();
+                             .flatMapToDouble(row -> IntStream.range(0, row.length).mapToDouble(i -> row[i]))
+                             .sum();
     }
 
     public FloatMask setWithOffset(FloatMask other, int xOffset, int yOffset, boolean center, boolean wrapEdges) {
@@ -897,7 +897,7 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
         return enqueue(dependencies -> {
             FloatMask source = (FloatMask) dependencies.get(0);
             applyWithOffset(source, (BiIntFloatConsumer) this::subtractPrimitiveAt, xOffset, yOffset, center,
-                    wrapEdges);
+                            wrapEdges);
         }, other);
     }
 
@@ -948,7 +948,7 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
         return enqueue(dependencies -> {
             FloatMask source = (FloatMask) dependencies.get(0);
             applyWithOffset(source, (BiIntFloatConsumer) this::multiplyPrimitiveAt, xOffset, yOffset, center,
-                    wrapEdges);
+                            wrapEdges);
         }, other);
     }
 
@@ -1046,24 +1046,24 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
             if (smallerSize == otherSize) {
                 if (symmetrySettings.spawnSymmetry().isPerfectSymmetry()) {
                     Map<Integer, Integer> coordinateXMap = getShiftedCoordinateMap(xOffset, center, wrapEdges,
-                            otherSize, size);
+                                                                                   otherSize, size);
                     Map<Integer, Integer> coordinateYMap = getShiftedCoordinateMap(yOffset, center, wrapEdges,
-                            otherSize, size);
+                                                                                   otherSize, size);
                     other.apply((x, y) -> {
                         int shiftX = coordinateXMap.get(x);
                         int shiftY = coordinateYMap.get(y);
                         if (inBounds(shiftX, shiftY)) {
                             float value = other.getPrimitive(x, y);
                             applyAtSymmetryPoints(shiftX, shiftY, SymmetryType.SPAWN,
-                                    (sx, sy) -> action.accept(sx, sy, value));
+                                                  (sx, sy) -> action.accept(sx, sy, value));
                         }
                     });
                 } else {
                     applyAtSymmetryPointsWithOutOfBounds(xOffset, yOffset, SymmetryType.SPAWN, (sx, sy) -> {
                         Map<Integer, Integer> coordinateXMap = getShiftedCoordinateMap(sx, center, wrapEdges, otherSize,
-                                size);
+                                                                                       size);
                         Map<Integer, Integer> coordinateYMap = getShiftedCoordinateMap(sy, center, wrapEdges, otherSize,
-                                size);
+                                                                                       size);
                         other.apply((x, y) -> {
                             int shiftX = coordinateXMap.get(x);
                             int shiftY = coordinateYMap.get(y);
@@ -1075,9 +1075,9 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
                 }
             } else {
                 Map<Integer, Integer> coordinateXMap = getShiftedCoordinateMap(xOffset, center, wrapEdges, size,
-                        otherSize);
+                                                                               otherSize);
                 Map<Integer, Integer> coordinateYMap = getShiftedCoordinateMap(yOffset, center, wrapEdges, size,
-                        otherSize);
+                                                                               otherSize);
                 apply((x, y) -> {
                     int shiftX = coordinateXMap.get(x);
                     int shiftY = coordinateYMap.get(y);

--- a/shared/src/main/java/com/faforever/neroxis/mask/FloatMask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/FloatMask.java
@@ -145,9 +145,9 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
         int gradientSize = size / resolution;
         float gradientScale = (float) size / gradientSize;
         Vector2Mask gradientVectors = new Vector2Mask(gradientSize +
-                                                              1, random.nextLong(), new SymmetrySettings(Symmetry.NONE),
+                                                      1, random.nextLong(), new SymmetrySettings(Symmetry.NONE),
                                                       getName() +
-                                                              "PerlinVectors", isParallel());
+                                                      "PerlinVectors", isParallel());
         gradientVectors.randomize(-1f, 1f).normalize();
         FloatMask noise = new FloatMask(size, null, symmetrySettings, getName() + "PerlinNoise", isParallel());
         noise.enqueue(dependencies -> {
@@ -362,7 +362,7 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
     public FloatMask removeAreasOfSpecifiedSizeWithLocalMaximums(int minSize, int maxSize, int levelOfPrecision, float floatMax) {
         for (int x = 0; x < levelOfPrecision; x++) {
             removeAreasInIntensityAndSize(minSize, maxSize, ((1f - (float) x / (float) levelOfPrecision) *
-                    floatMax), floatMax);
+                                                             floatMax), floatMax);
         }
         removeAreasInIntensityAndSize(minSize, maxSize, 0.0000001f, floatMax);
         return this;
@@ -449,8 +449,8 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
         enqueue(dependencies -> {
             BooleanMask source = (BooleanMask) dependencies.get(0);
             int frequency = (int) (density * (float) source.getCount() /
-                    26.21f /
-                    symmetrySettings.spawnSymmetry().getNumSymPoints());
+                                   26.21f /
+                                   symmetrySettings.spawnSymmetry().getNumSymPoints());
             useBrushWithinArea(source, brushName, size, frequency, intensity, wrapEdges);
         }, other);
         return this;
@@ -476,7 +476,7 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
         float slope = (float) StrictMath.tan(lightDirection.getElevation());
         BooleanMask shadowMask = new BooleanMask(getSize(), getNextSeed(), new SymmetrySettings(Symmetry.NONE),
                                                  getName() +
-                                                         "Shadow", isParallel());
+                                                 "Shadow", isParallel());
         return shadowMask.enqueue(dependencies -> shadowMask.apply((x, y) -> {
             FloatMask source = (FloatMask) dependencies.get(0);
             Vector2 location = new Vector2(x, y);
@@ -568,14 +568,14 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
                 Vector2 current = new Vector2(j, value);
                 Vector2 vertex = vertices.get(index);
                 float xIntersect = ((current.getY() + current.getX() * current.getX()) -
-                        (vertex.getY() + vertex.getX() * vertex.getX())) /
-                        (2 * current.getX() - 2 * vertex.getX());
+                                    (vertex.getY() + vertex.getX() * vertex.getX())) /
+                                   (2 * current.getX() - 2 * vertex.getX());
                 while (xIntersect <= intersections.get(index).getX()) {
                     index -= 1;
                     vertex = vertices.get(index);
                     xIntersect = ((current.getY() + current.getX() * current.getX()) -
-                            (vertex.getY() + vertex.getX() * vertex.getX())) /
-                            (2 * current.getX() - 2 * vertex.getX());
+                                  (vertex.getY() + vertex.getX() * vertex.getX())) /
+                                 (2 * current.getX() - 2 * vertex.getX());
                 }
                 index += 1;
                 if (index < vertices.size()) {

--- a/shared/src/main/java/com/faforever/neroxis/mask/IntegerMask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/IntegerMask.java
@@ -94,17 +94,17 @@ public final class IntegerMask extends PrimitiveMask<Integer, IntegerMask> {
     @Override
     public Integer getMin() {
         return Arrays.stream(mask)
-                .flatMapToInt(Arrays::stream)
-                .min()
-                .orElseThrow(() -> new IllegalStateException("Empty Mask"));
+                     .flatMapToInt(Arrays::stream)
+                     .min()
+                     .orElseThrow(() -> new IllegalStateException("Empty Mask"));
     }
 
     @Override
     public Integer getMax() {
         return Arrays.stream(mask)
-                .flatMapToInt(Arrays::stream)
-                .max()
-                .orElseThrow(() -> new IllegalStateException("Empty Mask"));
+                     .flatMapToInt(Arrays::stream)
+                     .max()
+                     .orElseThrow(() -> new IllegalStateException("Empty Mask"));
     }
 
     @Override
@@ -528,24 +528,24 @@ public final class IntegerMask extends PrimitiveMask<Integer, IntegerMask> {
             if (smallerSize == otherSize) {
                 if (symmetrySettings.spawnSymmetry().isPerfectSymmetry()) {
                     Map<Integer, Integer> coordinateXMap = getShiftedCoordinateMap(xOffset, center, wrapEdges,
-                            otherSize, size);
+                                                                                   otherSize, size);
                     Map<Integer, Integer> coordinateYMap = getShiftedCoordinateMap(yOffset, center, wrapEdges,
-                            otherSize, size);
+                                                                                   otherSize, size);
                     other.apply((x, y) -> {
                         int shiftX = coordinateXMap.get(x);
                         int shiftY = coordinateYMap.get(y);
                         if (inBounds(shiftX, shiftY)) {
                             int value = other.getPrimitive(x, y);
                             applyAtSymmetryPoints(shiftX, shiftY, SymmetryType.SPAWN,
-                                    (sx, sy) -> action.accept(x, y, value));
+                                                  (sx, sy) -> action.accept(x, y, value));
                         }
                     });
                 } else {
                     applyAtSymmetryPointsWithOutOfBounds(xOffset, yOffset, SymmetryType.SPAWN, (sx, sy) -> {
                         Map<Integer, Integer> coordinateXMap = getShiftedCoordinateMap(sx, center, wrapEdges, otherSize,
-                                size);
+                                                                                       size);
                         Map<Integer, Integer> coordinateYMap = getShiftedCoordinateMap(sy, center, wrapEdges, otherSize,
-                                size);
+                                                                                       size);
                         other.apply((x, y) -> {
                             int shiftX = coordinateXMap.get(x);
                             int shiftY = coordinateYMap.get(y);
@@ -557,9 +557,9 @@ public final class IntegerMask extends PrimitiveMask<Integer, IntegerMask> {
                 }
             } else {
                 Map<Integer, Integer> coordinateXMap = getShiftedCoordinateMap(xOffset, center, wrapEdges, size,
-                        otherSize);
+                                                                               otherSize);
                 Map<Integer, Integer> coordinateYMap = getShiftedCoordinateMap(yOffset, center, wrapEdges, size,
-                        otherSize);
+                                                                               otherSize);
                 apply((x, y) -> {
                     int shiftX = coordinateXMap.get(x);
                     int shiftY = coordinateYMap.get(y);

--- a/shared/src/main/java/com/faforever/neroxis/mask/IntegerMask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/IntegerMask.java
@@ -94,17 +94,17 @@ public final class IntegerMask extends PrimitiveMask<Integer, IntegerMask> {
     @Override
     public Integer getMin() {
         return Arrays.stream(mask)
-                     .flatMapToInt(Arrays::stream)
-                     .min()
-                     .orElseThrow(() -> new IllegalStateException("Empty Mask"));
+                .flatMapToInt(Arrays::stream)
+                .min()
+                .orElseThrow(() -> new IllegalStateException("Empty Mask"));
     }
 
     @Override
     public Integer getMax() {
         return Arrays.stream(mask)
-                     .flatMapToInt(Arrays::stream)
-                     .max()
-                     .orElseThrow(() -> new IllegalStateException("Empty Mask"));
+                .flatMapToInt(Arrays::stream)
+                .max()
+                .orElseThrow(() -> new IllegalStateException("Empty Mask"));
     }
 
     @Override
@@ -209,10 +209,7 @@ public final class IntegerMask extends PrimitiveMask<Integer, IntegerMask> {
                 int[][] oldMask = mask;
                 initializeMask(newSize);
                 Map<Integer, Integer> coordinateMap = getSymmetricScalingCoordinateMap(oldSize, newSize);
-                applyWithSymmetry(SymmetryType.SPAWN, (x, y) -> {
-                    int value = oldMask[coordinateMap.get(x)][coordinateMap.get(y)];
-                    applyAtSymmetryPoints(x, y, SymmetryType.SPAWN, (sx, sy) -> setPrimitive(sx, sy, value));
-                });
+                apply((x, y) -> setPrimitive(x, y, oldMask[coordinateMap.get(x)][coordinateMap.get(y)]));
             }
         });
     }
@@ -531,24 +528,24 @@ public final class IntegerMask extends PrimitiveMask<Integer, IntegerMask> {
             if (smallerSize == otherSize) {
                 if (symmetrySettings.spawnSymmetry().isPerfectSymmetry()) {
                     Map<Integer, Integer> coordinateXMap = getShiftedCoordinateMap(xOffset, center, wrapEdges,
-                                                                                   otherSize, size);
+                            otherSize, size);
                     Map<Integer, Integer> coordinateYMap = getShiftedCoordinateMap(yOffset, center, wrapEdges,
-                                                                                   otherSize, size);
+                            otherSize, size);
                     other.apply((x, y) -> {
                         int shiftX = coordinateXMap.get(x);
                         int shiftY = coordinateYMap.get(y);
                         if (inBounds(shiftX, shiftY)) {
                             int value = other.getPrimitive(x, y);
                             applyAtSymmetryPoints(shiftX, shiftY, SymmetryType.SPAWN,
-                                                  (sx, sy) -> action.accept(x, y, value));
+                                    (sx, sy) -> action.accept(x, y, value));
                         }
                     });
                 } else {
                     applyAtSymmetryPointsWithOutOfBounds(xOffset, yOffset, SymmetryType.SPAWN, (sx, sy) -> {
                         Map<Integer, Integer> coordinateXMap = getShiftedCoordinateMap(sx, center, wrapEdges, otherSize,
-                                                                                       size);
+                                size);
                         Map<Integer, Integer> coordinateYMap = getShiftedCoordinateMap(sy, center, wrapEdges, otherSize,
-                                                                                       size);
+                                size);
                         other.apply((x, y) -> {
                             int shiftX = coordinateXMap.get(x);
                             int shiftY = coordinateYMap.get(y);
@@ -560,9 +557,9 @@ public final class IntegerMask extends PrimitiveMask<Integer, IntegerMask> {
                 }
             } else {
                 Map<Integer, Integer> coordinateXMap = getShiftedCoordinateMap(xOffset, center, wrapEdges, size,
-                                                                               otherSize);
+                        otherSize);
                 Map<Integer, Integer> coordinateYMap = getShiftedCoordinateMap(yOffset, center, wrapEdges, size,
-                                                                               otherSize);
+                        otherSize);
                 apply((x, y) -> {
                     int shiftX = coordinateXMap.get(x);
                     int shiftY = coordinateYMap.get(y);

--- a/shared/src/main/java/com/faforever/neroxis/mask/Mask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/Mask.java
@@ -54,7 +54,7 @@ public abstract sealed class Mask<T, U extends Mask<T, U>> permits OperationsMas
 
     protected Mask(U other, String name) {
         this(other.getSize(), (name != null && name.endsWith(MOCK_NAME)) ? null : other.getNextSeed(),
-                other.getSymmetrySettings(), name, other.isParallel());
+             other.getSymmetrySettings(), name, other.isParallel());
         init(other);
     }
 
@@ -387,7 +387,7 @@ public abstract sealed class Mask<T, U extends Mask<T, U>> permits OperationsMas
         float size = getSize();
         if (hasSet != null) {
             // Keep track of pixels that we've set
-            hasSet[(int)x][(int)y] = true;
+            hasSet[(int) x][(int) y] = true;
         }
         switch (symmetry) {
             case POINT2 -> symmetryPoints.add(new Vector2(size - x - 1, size - y - 1));
@@ -668,7 +668,7 @@ public abstract sealed class Mask<T, U extends Mask<T, U>> permits OperationsMas
         return enqueue(() -> {
             loopWithSymmetry(symmetryType, maskAction);
             if (!symmetrySettings.getSymmetry(symmetryType).isPerfectSymmetry() && symmetrySettings.spawnSymmetry()
-                    .isPerfectSymmetry()) {
+                                                                                                   .isPerfectSymmetry()) {
                 forceSymmetry(SymmetryType.SPAWN);
             }
         });
@@ -758,24 +758,24 @@ public abstract sealed class Mask<T, U extends Mask<T, U>> permits OperationsMas
             if (smallerSize == otherSize) {
                 if (symmetrySettings.spawnSymmetry().isPerfectSymmetry()) {
                     Map<Integer, Integer> coordinateXMap = getShiftedCoordinateMap(xOffset, center, wrapEdges,
-                            otherSize, size);
+                                                                                   otherSize, size);
                     Map<Integer, Integer> coordinateYMap = getShiftedCoordinateMap(yOffset, center, wrapEdges,
-                            otherSize, size);
+                                                                                   otherSize, size);
                     other.apply((x, y) -> {
                         int shiftX = coordinateXMap.get(x);
                         int shiftY = coordinateYMap.get(y);
                         if (inBounds(shiftX, shiftY)) {
                             T value = other.get(x, y);
                             applyAtSymmetryPoints(shiftX, shiftY, SymmetryType.SPAWN,
-                                    (sx, sy) -> action.accept(sx, sy, value));
+                                                  (sx, sy) -> action.accept(sx, sy, value));
                         }
                     });
                 } else {
                     applyAtSymmetryPointsWithOutOfBounds(xOffset, yOffset, SymmetryType.SPAWN, (sx, sy) -> {
                         Map<Integer, Integer> coordinateXMap = getShiftedCoordinateMap(sx, center, wrapEdges, otherSize,
-                                size);
+                                                                                       size);
                         Map<Integer, Integer> coordinateYMap = getShiftedCoordinateMap(sy, center, wrapEdges, otherSize,
-                                size);
+                                                                                       size);
                         other.apply((x, y) -> {
                             int shiftX = coordinateXMap.get(x);
                             int shiftY = coordinateYMap.get(y);
@@ -787,9 +787,9 @@ public abstract sealed class Mask<T, U extends Mask<T, U>> permits OperationsMas
                 }
             } else {
                 Map<Integer, Integer> coordinateXMap = getShiftedCoordinateMap(xOffset, center, wrapEdges, size,
-                        otherSize);
+                                                                               otherSize);
                 Map<Integer, Integer> coordinateYMap = getShiftedCoordinateMap(yOffset, center, wrapEdges, size,
-                        otherSize);
+                                                                               otherSize);
                 apply((x, y) -> {
                     int shiftX = coordinateXMap.get(x);
                     int shiftY = coordinateYMap.get(y);
@@ -838,8 +838,8 @@ public abstract sealed class Mask<T, U extends Mask<T, U>> permits OperationsMas
         }
 
         return IntStream.range(0, fromSize)
-                .boxed()
-                .collect(Collectors.toMap(i -> i, i -> getShiftedValue(i, trueOffset, toSize, wrapEdges)));
+                        .boxed()
+                        .collect(Collectors.toMap(i -> i, i -> getShiftedValue(i, trueOffset, toSize, wrapEdges)));
     }
 
     protected void loopWithSymmetry(SymmetryType symmetryType, BiIntConsumer maskAction) {
@@ -869,7 +869,7 @@ public abstract sealed class Mask<T, U extends Mask<T, U>> permits OperationsMas
         if (symmetrySettings.spawnSymmetry() != Symmetry.NONE && !symmetrySettings.equals(otherSymmetrySettings)) {
             throw new IllegalArgumentException(
                     String.format("Masks not the same symmetry: %s is %s and %s is %s", name, symmetrySettings,
-                            otherName, otherSymmetrySettings));
+                                  otherName, otherSymmetrySettings));
         }
         if (isParallel() && !Pipeline.isRunning() && !other.isParallel()) {
             throw new IllegalArgumentException(
@@ -951,14 +951,14 @@ public abstract sealed class Mask<T, U extends Mask<T, U>> permits OperationsMas
             int size = getSize();
             switch (symmetrySettings.getSymmetry(symmetryType)) {
                 case Z -> fillRect(0, 0, extent / 2, size, value).fillRect(size - extent / 2, 0, size - extent / 2,
-                        size, value);
+                                                                           size, value);
                 case X -> fillRect(0, 0, size, extent / 2, value).fillRect(0, size - extent / 2, size, extent / 2,
-                        value);
+                                                                           value);
                 case XZ -> fillParallelogram(0, 0, size, extent * 3 / 4, 0, -1, value).fillParallelogram(
                         size - extent * 3 / 4, size, size, extent * 3 / 4, 0, -1, value);
                 case ZX -> fillParallelogram(size - extent * 3 / 4, 0, extent * 3 / 4, extent * 3 / 4, 1, 0,
-                        value).fillParallelogram(-extent * 3 / 4, size - extent * 3 / 4,
-                        extent * 3 / 4, extent * 3 / 4, 1, 0, value);
+                                             value).fillParallelogram(-extent * 3 / 4, size - extent * 3 / 4,
+                                                                      extent * 3 / 4, extent * 3 / 4, 1, 0, value);
             }
             forceSymmetry(symmetryType);
         });
@@ -1129,7 +1129,7 @@ public abstract sealed class Mask<T, U extends Mask<T, U>> permits OperationsMas
     protected U fillCoordinates(Collection<Vector2> coordinates, T value) {
         coordinates.forEach(
                 location -> applyAtSymmetryPoints((int) location.getX(), (int) location.getY(), SymmetryType.SPAWN,
-                        (x, y) -> set(x, y, value)));
+                                                  (x, y) -> set(x, y, value)));
         return (U) this;
     }
 }

--- a/shared/src/main/java/com/faforever/neroxis/mask/Mask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/Mask.java
@@ -233,7 +233,7 @@ public abstract sealed class Mask<T, U extends Mask<T, U>> permits OperationsMas
             function.accept(dependencies);
             visible = visibleState;
             if (((DebugUtil.DEBUG && isVisualDebug()) || (DebugUtil.VISUALIZE && !isMock() && !isParallel())) &&
-                    visible) {
+                visible) {
                 String callingMethod = DebugUtil.getLastStackTraceMethodInPackage("com.faforever.neroxis.mask");
                 String callingLine = DebugUtil.getLastStackTraceLineAfterPackage("com.faforever.neroxis.mask");
                 VisualDebugger.visualizeMask(this, callingMethod, callingLine);
@@ -626,7 +626,7 @@ public abstract sealed class Mask<T, U extends Mask<T, U>> permits OperationsMas
     public boolean inHalfNoBounds(Vector2 pos, float angle) {
         float halfSize = getSize() / 2f;
         float vectorAngle = (float) ((new Vector2(halfSize, halfSize).angleTo(pos) * 180f / StrictMath.PI) + 90f + 360f)
-                % 360f;
+                            % 360f;
         float adjustedAngle = (angle + 180f) % 360f;
         if (angle >= 180) {
             return (vectorAngle >= angle || vectorAngle < adjustedAngle);
@@ -693,7 +693,7 @@ public abstract sealed class Mask<T, U extends Mask<T, U>> permits OperationsMas
     public boolean inHalf(Vector2 pos, float angle) {
         float halfSize = getSize() / 2f;
         float vectorAngle = (float) ((new Vector2(halfSize, halfSize).angleTo(pos) * 180f / StrictMath.PI) + 90f + 360f)
-                % 360f;
+                            % 360f;
         float adjustedAngle = (angle + 180f) % 360f;
         if (angle >= 180) {
             return (vectorAngle >= angle || vectorAngle < adjustedAngle) && inBounds(pos);


### PR DESCRIPTION
So after much digging and debugging, I found the main cause of the issue with Odd Symmetry mapgens.
I basically affects functions that use `applyWithSymmetry()`

And the reason is because points can land on the same pixel after rotation:
![after_rotation](https://github.com/FAForever/Neroxis-Map-Generator/assets/11024011/a7ca2a0e-f201-4377-91f6-41fe5cd7c77a)

And then some points don't get filled in, and are missed.

So I've played with some strategies to resolve this issue, and so far it's looking pretty decent.