### PR TITLE
Odd summetry fix take2

### DIFF
--- a/shared/src/main/java/com/faforever/neroxis/mask/BooleanMask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/BooleanMask.java
@@ -229,13 +229,10 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
             } else if (oldSize != newSize) {
                 long[] oldMask = mask;
                 initializeMask(newSize);
-
-                float scale = (float)oldSize / (float)newSize;
-
+                Map<Integer, Integer> coordinateMap = getSymmetricScalingCoordinateMap(oldSize, newSize);
                 apply((x, y) -> {
-                    int sx = (int)(x * scale);
-                    int sy = (int)(y * scale);
-                    setPrimitive(x, y, getBit(sx, sy, oldSize, oldMask));
+                    boolean value = getBit(coordinateMap.get(x), coordinateMap.get(y), oldSize, oldMask);
+                    setPrimitive(x, y, value);
                 });
             }
         });

--- a/shared/src/main/java/com/faforever/neroxis/mask/FloatMask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/FloatMask.java
@@ -662,13 +662,10 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
             } else if (oldSize != newSize) {
                 float[][] oldMask = mask;
                 initializeMask(newSize);
-
-                float scale = (float)oldSize / (float)newSize;
-
+                Map<Integer, Integer> coordinateMap = getSymmetricScalingCoordinateMap(oldSize, newSize);
                 apply((x, y) -> {
-                    int sx = (int)(x * scale);
-                    int sy = (int)(y * scale);
-                    setPrimitive(x, y, oldMask[sx][sy]);
+                    float value = oldMask[coordinateMap.get(x)][coordinateMap.get(y)];
+                    setPrimitive(x, y, value);
                 });
             }
         });

--- a/shared/src/main/java/com/faforever/neroxis/mask/Mask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/Mask.java
@@ -403,7 +403,7 @@ public abstract sealed class Mask<T, U extends Mask<T, U>> permits OperationsMas
             case POINT3, POINT5, POINT7, POINT9, POINT11, POINT13, POINT15 -> {
                 for (int i = 1; i < numSymPoints; i++) {
                     Vector2 rotated = getRotatedPoint(x, y, (float) (2 * StrictMath.PI * i / numSymPoints));
-                        symmetryPoints.add(rotated);
+                    symmetryPoints.add(rotated);
                 }
             }
             case X -> symmetryPoints.add(new Vector2(size - x - 1, y));

--- a/shared/src/main/java/com/faforever/neroxis/mask/Mask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/Mask.java
@@ -403,7 +403,7 @@ public abstract sealed class Mask<T, U extends Mask<T, U>> permits OperationsMas
             case POINT3, POINT5, POINT7, POINT9, POINT11, POINT13, POINT15 -> {
                 for (int i = 1; i < numSymPoints; i++) {
                     Vector2 rotated = getRotatedPoint(x, y, (float) (2 * StrictMath.PI * i / numSymPoints));
-                    symmetryPoints.add(rotated);
+                        symmetryPoints.add(rotated);
                 }
             }
             case X -> symmetryPoints.add(new Vector2(size - x - 1, y));
@@ -617,10 +617,16 @@ public abstract sealed class Mask<T, U extends Mask<T, U>> permits OperationsMas
 
     public U forceSymmetry(SymmetryType symmetryType, boolean reverse) {
         if (!reverse) {
-            return applyWithSymmetry(symmetryType, (x, y) -> {
-                T value = get(x, y);
-                applyAtSymmetryPoints(x, y, symmetryType, (sx, sy) -> set(sx, sy, value));
-            });
+            boolean isPerfectSym = symmetrySettings.getSymmetry(SymmetryType.SPAWN).isPerfectSymmetry();
+            if (!isPerfectSym) {
+                // When we don't have a perfect symmetry, we can skip this.
+                return enqueue(() -> {});
+            } else {
+                return applyWithSymmetry(symmetryType, (x, y) -> {
+                    T value = get(x, y);
+                    applyAtSymmetryPoints(x, y, symmetryType, (sx, sy) -> set(sx, sy, value));
+                });
+            }
         } else {
             if (symmetrySettings.getSymmetry(symmetryType).getNumSymPoints() != 2) {
                 throw new IllegalArgumentException("Symmetry has more than two symmetry points");
@@ -680,6 +686,43 @@ public abstract sealed class Mask<T, U extends Mask<T, U>> permits OperationsMas
 
     public boolean inBounds(Vector2 location) {
         return inBounds(StrictMath.round(location.getX()), StrictMath.round(location.getY()));
+    }
+
+    void copyPrimitiveFromReverseLookup(int x, int y) {
+        int numSpawns = symmetrySettings.spawnSymmetry().getNumSymPoints();
+        double radiansPerSlice = StrictMath.PI * 2 / numSpawns;
+        int size = getSize();
+        int dx = x - (size / 2);
+        int dy = y - (size / 2);
+
+        // Find the angle of this point relative to the center of the map
+        double angle = StrictMath.atan2(dy, dx);
+        if (y < 0) {
+            angle = StrictMath.PI - angle;
+        } else {
+            angle = StrictMath.PI + angle;
+        }
+
+        // Find out what slice of the pie this pixel sits in
+        int slice = (int) (angle / radiansPerSlice);
+        if (slice > 0) {
+            // Find the angle we need to rotate, in order to lookup this pixels value on the original slice.
+            double antiRotateAngle = -slice * radiansPerSlice;
+
+            // Find the X and Y coords of this pixel in the original slice
+            float halfSize = size / 2f;
+            float xOffset = x - halfSize;
+            float yOffset = y - halfSize;
+            double cosAngle = StrictMath.cos(antiRotateAngle);
+            double sinAngle = StrictMath.sin(antiRotateAngle);
+            float antiRotatedX = (float) (xOffset * cosAngle - yOffset * sinAngle + halfSize);
+            float antiRotatedY = (float) (xOffset * sinAngle + yOffset * cosAngle + halfSize);
+
+            // Copy the value from the original slice
+            if (inBounds((int) antiRotatedX, (int) antiRotatedY)) {
+                set(x, y, get((int) antiRotatedX, (int) antiRotatedY));
+            }
+        }
     }
 
     public U forceSymmetry(SymmetryType symmetryType) {


### PR DESCRIPTION
So been working on this for a while, managed to get the reverse lookup working.
Results are really good, and any map that is generated with Perfect Symmetry is unaffected by any of these code changes.

Note: I had to change the `setSizeInternal()` function, because the use of `applyWithSymmetry()` was causing issues.
So I simplified it, a lot, and it is the same efficiecy, maybe more efficient.

The rest of it relies on the `copyPrimitiveFromReverseLookup()` function, which logically divides the map into slices, and for the 2nd, 3rd, 4th, etc slice, it copies it's value from the 1st slice.

This is a look at a 7 player map generated with these changes:
![image](https://github.com/user-attachments/assets/ab520da5-f91b-45e1-b9f3-66728c41a416)
