### PR TITLE
This seeming small optimization has a surprisingly big effect.

### DIFF
--- a/shared/src/main/java/com/faforever/neroxis/mask/BooleanMask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/BooleanMask.java
@@ -898,6 +898,7 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
 
     private void markInRadius(float radius, long[] maskCopy, int x, int y, boolean value) {
         float radius2 = (radius + 0.5f) * (radius + 0.5f);
+        int size = getSize();
         int searchRange = (int) StrictMath.ceil(radius);
         int minX = x - searchRange;
         int maxX = x + searchRange + 1;
@@ -905,7 +906,7 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
         int maxY = y + searchRange + 1;
         for (int x2 = minX; x2 < maxX; ++x2) {
             for (int y2 = minY; y2 < maxY; ++y2) {
-                int bitIndex = bitIndex(x2, y2, getSize());
+                int bitIndex = bitIndex(x2, y2, size);
                 if (inBounds(x2, y2)
                     && getBit(bitIndex, maskCopy) != value
                     && (x - x2) * (x - x2) + (y - y2) * (y - y2) <= radius2) {


### PR DESCRIPTION
So this function is used by `inflate()` and I noticed it could be optimized by calling getSize() once at the start of the function.
All other functions already have this optimization, maybe this one was just missed.

I didn't actually think it would make much of a difference, but I tried anyway to see.

And yeah this function seems to be about 20% faster after this change, which is surprising. I guess the cost of associated with function calls can actually be impactful some times...

I found that in a 40K mapgen which takes around 28 seconds in total on my PC:
Before:
Entry Done: function time 3212 ms; hash time    0 ms; heightmapPlateaustoBooleanCopy(234); BasicTerrainGenerator.java:358  -> inflate

After:
Entry Done: function time 2565 ms; hash time    0 ms; heightmapPlateaustoBooleanCopy(234); BasicTerrainGenerator.java:358  -> inflate

Total of all 35 inflate calls before was 8681 ms and after this optimization was 6321 ms.

So somehow it saves about 2 seconds generate time on a 40K mapgen.





















































