### PR TITLE
Exit program with appropriate status

### DIFF
--- a/generator/src/main/java/com/faforever/neroxis/generator/MapGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/MapGenerator.java
@@ -88,13 +88,24 @@ public class MapGenerator implements Callable<Integer> {
             int numToGenerate = numToGenerateParser.parseArgs(args).matchedOptionValue("num-to-generate", 1);
 
             for (int i = 0; i < numToGenerate; i++) {
-                CommandLine commandLine = new CommandLine(new MapGenerator());
-                commandLine.setAbbreviatedOptionsAllowed(true);
-                commandLine.setUnmatchedArgumentsAllowed(true);
-                commandLine.execute(args);
+                exitIfError(execute(args));
             }
             Pipeline.shutdown();
         });
+    }
+
+    public static Integer execute(String[] args) {
+        CommandLine commandLine = new CommandLine(new MapGenerator());
+        commandLine.setAbbreviatedOptionsAllowed(true);
+        commandLine.setUnmatchedArgumentsAllowed(true);
+        return commandLine.execute(args);
+    }
+
+    private static void exitIfError(Integer status) {
+        if (status != 0) {
+            Pipeline.shutdown();
+            System.exit(status);
+        }
     }
 
     @Option(names = "--preview-path", order = 10000, description = "Folder to save the map previews to")


### PR DESCRIPTION
Currently if a user specifies incompatible options (like `--num-teams 2 --terrain-symmetry POINT3`) the program will exit with status code `0`, but won't generate any map. Although it will print problem description and the output of `--help` command `--num-to-generate` times.

This PR attempts to address this issue -- the program will exit with non-zero code on error and won't try to further generate maps with problematic arguments after the first failure.