### PR TITLE
Allow visual debugging from any thread

### DIFF
--- a/shared/src/main/java/com/faforever/neroxis/visualization/VisualDebugger.java
+++ b/shared/src/main/java/com/faforever/neroxis/visualization/VisualDebugger.java
@@ -20,10 +20,18 @@ public class VisualDebugger {
     }
 
     public static void visualizeMask(Mask<?, ?> mask, String method, String line) {
-        createGui();
-        String name = mask.getVisualName();
-        name = name == null ? mask.getName() : name;
-        updateList(name + " " + method + " " + line, mask.immutableCopy());
+        Mask<?, ?> copyOfmask = mask.copy();
+        SwingUtilities.invokeLater(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        createGui();
+                        String name = copyOfmask.getVisualName();
+                        name = name == null ? copyOfmask.getName() : name;
+                        updateList(name + " " + method + " " + line, copyOfmask.immutableCopy());
+                    }
+                }
+        );
     }
 
     public static void createGui() {

--- a/shared/src/main/java/com/faforever/neroxis/visualization/VisualDebugger.java
+++ b/shared/src/main/java/com/faforever/neroxis/visualization/VisualDebugger.java
@@ -20,14 +20,14 @@ public class VisualDebugger {
     }
 
     public static void visualizeMask(Mask<?, ?> mask, String method, String line) {
-        Mask<?, ?> copyOfmask = mask.copy();
-        copyOfmask = mask.immutableCopy()
+        Mask<?, ?> copyOfmask = mask.immutableCopy();
         SwingUtilities.invokeLater(() -> {
-                        createGui();
-                        String name = copyOfmask.getVisualName();
-                        name = name == null ? copyOfmask.getName() : name;
-                        updateList(name + " " + method + " " + line, copyOfmask);
-                    });
+                                       createGui();
+                                       String name = copyOfmask.getVisualName();
+                                       name = name == null ? copyOfmask.getName() : name;
+                                       updateList(name + " " + method + " " + line, copyOfmask.immutableCopy());
+                                   }
+        );
     }
 
     public static void createGui() {

--- a/shared/src/main/java/com/faforever/neroxis/visualization/VisualDebugger.java
+++ b/shared/src/main/java/com/faforever/neroxis/visualization/VisualDebugger.java
@@ -21,17 +21,13 @@ public class VisualDebugger {
 
     public static void visualizeMask(Mask<?, ?> mask, String method, String line) {
         Mask<?, ?> copyOfmask = mask.copy();
-        SwingUtilities.invokeLater(
-                new Runnable() {
-                    @Override
-                    public void run() {
+        copyOfmask = mask.immutableCopy()
+        SwingUtilities.invokeLater(() -> {
                         createGui();
                         String name = copyOfmask.getVisualName();
                         name = name == null ? copyOfmask.getName() : name;
-                        updateList(name + " " + method + " " + line, copyOfmask.immutableCopy());
-                    }
-                }
-        );
+                        updateList(name + " " + method + " " + line, copyOfmask);
+                    });
     }
 
     public static void createGui() {


### PR DESCRIPTION
This is a small change to make the Visual Debugger work when generating a map.
When doing Swing UI updates, it must be run from the UI thread.
So this uses `SwingUtilities.invokeLater()` to make sure UI updates are run from the UI thread.

Which is nice because we can reliably debug the entire map generation if desired:
EG: this works now without issue:
![image](https://github.com/user-attachments/assets/fbd11b1b-6d87-413f-bb6e-d0639092165a)
