### PR TITLE
Encode dds as ARGB instead of ABGR

### DIFF
--- a/shared/src/main/java/com/faforever/neroxis/util/ImageUtil.java
+++ b/shared/src/main/java/com/faforever/neroxis/util/ImageUtil.java
@@ -288,25 +288,6 @@ public class ImageUtil {
         return allBytes;
     }
 
-    private static byte[] getRawDDSImageBytes(int size, ByteBuffer imageByteBuffer) {
-        DDSHeader ddsHeader = new DDSHeader();
-        ddsHeader.setWidth(size);
-        ddsHeader.setHeight(size);
-        ddsHeader.setRGBBitCount(32);
-        ddsHeader.setRBitMask(0x000000FF);
-        ddsHeader.setGBitMask(0x0000FF00);
-        ddsHeader.setBBitMask(0x00FF0000);
-        ddsHeader.setABitMask(0xFF000000);
-        ddsHeader.toBytes();
-        byte[] headerBytes = ddsHeader.toBytes();
-        byte[] imageBytes = imageByteBuffer.array();
-        int headerLength = headerBytes.length;
-        int imageLength = size * size * 4;
-        byte[] allBytes = Arrays.copyOf(headerBytes, headerLength + imageLength);
-        System.arraycopy(imageBytes, 0, allBytes, headerLength, imageLength);
-        return allBytes;
-    }
-
     public static void writeAutoScaledPNGFromMasks(FloatMask redMask, FloatMask greenMask, FloatMask blueMask,
                                                    Path path) throws IOException {
         float scaleMultiplier = 255 / StrictMath.max(StrictMath.max(redMask.getMax(), greenMask.getMax()),

--- a/shared/src/main/java/com/faforever/neroxis/util/ImageUtil.java
+++ b/shared/src/main/java/com/faforever/neroxis/util/ImageUtil.java
@@ -159,10 +159,10 @@ public class ImageUtil {
         ddsHeader.setWidth(size);
         ddsHeader.setHeight(size);
         ddsHeader.setRGBBitCount(32);
-        ddsHeader.setRBitMask(0x000000FF);
-        ddsHeader.setGBitMask(0x0000FF00);
-        ddsHeader.setBBitMask(0x00FF0000);
         ddsHeader.setABitMask(0xFF000000);
+        ddsHeader.setRBitMask(0x00FF0000);
+        ddsHeader.setGBitMask(0x0000FF00);
+        ddsHeader.setBBitMask(0x000000FF);
 
         // If we don't do this we get weird results when the file already exists
         Files.deleteIfExists(path);

--- a/shared/src/main/java/com/faforever/neroxis/util/ImageUtil.java
+++ b/shared/src/main/java/com/faforever/neroxis/util/ImageUtil.java
@@ -150,19 +150,20 @@ public class ImageUtil {
         for (int y = 0; y < size; y++) {
             for (int x = 0; x < size; x++) {
                 int[] values = imageRaster.getPixel(x, y, new int[4]);
-                for (int val : values) {
-                    imageBytes.put((byte) val);
-                }
+                imageBytes.put((byte) values[2]);
+                imageBytes.put((byte) values[1]);
+                imageBytes.put((byte) values[0]);
+                imageBytes.put((byte) values[3]);
             }
         }
         DDSHeader ddsHeader = new DDSHeader();
         ddsHeader.setWidth(size);
         ddsHeader.setHeight(size);
         ddsHeader.setRGBBitCount(32);
-        ddsHeader.setABitMask(0xFF000000);
-        ddsHeader.setRBitMask(0x00FF0000);
-        ddsHeader.setGBitMask(0x0000FF00);
         ddsHeader.setBBitMask(0x000000FF);
+        ddsHeader.setGBitMask(0x0000FF00);
+        ddsHeader.setRBitMask(0x00FF0000);
+        ddsHeader.setABitMask(0xFF000000);
 
         // If we don't do this we get weird results when the file already exists
         Files.deleteIfExists(path);


### PR DESCRIPTION
ABGR is a pretty unusual format. Most software can deal with this just fine, but our unity map editor can't deal with it and reads it as ARGB which causes problems.
Instead of trying to fix the map editor, which would be complicated because unity doesn't even know the ABGR format, we can just output a more standard format here.