### PR TITLE
Accomodate to new shader changes

### DIFF
--- a/generator/src/main/java/com/faforever/neroxis/generator/TextureStyle.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/TextureStyle.java
@@ -1,6 +1,7 @@
 package com.faforever.neroxis.generator;
 
 import com.faforever.neroxis.generator.texture.BrimstoneTextureGenerator;
+import com.faforever.neroxis.generator.texture.CrystallineTextureGenerator;
 import com.faforever.neroxis.generator.texture.DesertTextureGenerator;
 import com.faforever.neroxis.generator.texture.EarlyAutumnTextureGenerator;
 import com.faforever.neroxis.generator.texture.FrithenTextureGenerator;
@@ -8,11 +9,9 @@ import com.faforever.neroxis.generator.texture.MarsTextureGenerator;
 import com.faforever.neroxis.generator.texture.MoonlightTextureGenerator;
 import com.faforever.neroxis.generator.texture.PrayerTextureGenerator;
 import com.faforever.neroxis.generator.texture.StonesTextureGenerator;
-import com.faforever.neroxis.generator.texture.SunsetTextureGenerator;
 import com.faforever.neroxis.generator.texture.SyrtisTextureGenerator;
 import com.faforever.neroxis.generator.texture.WindingRiverTextureGenerator;
 import com.faforever.neroxis.generator.texture.WonderTextureGenerator;
-import com.faforever.neroxis.generator.texture.CrystallineTextureGenerator;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -29,7 +28,7 @@ public enum TextureStyle {
     MOONLIGHT(MoonlightTextureGenerator::new, "Moonlight"),
     PRAYER(PrayerTextureGenerator::new, "Prayer"),
     STONES(StonesTextureGenerator::new, "Stones"),
-    SUNSET(SunsetTextureGenerator::new, "Sunset"),
+    //SUNSET(SunsetTextureGenerator::new, "Sunset"),
     SYRTIS(SyrtisTextureGenerator::new, "Syrtis"),
     WINDINGRIVER(WindingRiverTextureGenerator::new, "WindingRiver"),
     WONDER(WonderTextureGenerator::new, "Wonder"),

--- a/generator/src/main/java/com/faforever/neroxis/generator/style/HighReclaimStyleGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/style/HighReclaimStyleGenerator.java
@@ -13,7 +13,7 @@ import com.faforever.neroxis.generator.terrain.TerrainGenerator;
 import com.faforever.neroxis.generator.terrain.ValleyTerrainGenerator;
 import com.faforever.neroxis.generator.texture.DesertTextureGenerator;
 import com.faforever.neroxis.generator.texture.FrithenTextureGenerator;
-import com.faforever.neroxis.generator.texture.SunsetTextureGenerator;
+import com.faforever.neroxis.generator.texture.MoonlightTextureGenerator;
 import com.faforever.neroxis.generator.texture.TextureGenerator;
 import com.faforever.neroxis.generator.texture.WonderTextureGenerator;
 
@@ -40,7 +40,8 @@ public class HighReclaimStyleGenerator extends StyleGenerator {
         return WeightedOptionsWithFallback.of(new DesertTextureGenerator(),
                                               new WeightedOption<>(new DesertTextureGenerator(), 1f),
                                               new WeightedOption<>(new FrithenTextureGenerator(), 1f),
-                                              new WeightedOption<>(new SunsetTextureGenerator(), 1f),
+                                              new WeightedOption<>(new MoonlightTextureGenerator(), 1f),
+                                              // new WeightedOption<>(new SunsetTextureGenerator(), 1f),
                                               new WeightedOption<>(new WonderTextureGenerator(), 1f));
     }
 }

--- a/generator/src/main/java/com/faforever/neroxis/generator/style/StyleGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/style/StyleGenerator.java
@@ -20,7 +20,6 @@ import com.faforever.neroxis.generator.texture.FrithenTextureGenerator;
 import com.faforever.neroxis.generator.texture.MarsTextureGenerator;
 import com.faforever.neroxis.generator.texture.PrayerTextureGenerator;
 import com.faforever.neroxis.generator.texture.StonesTextureGenerator;
-import com.faforever.neroxis.generator.texture.SunsetTextureGenerator;
 import com.faforever.neroxis.generator.texture.SyrtisTextureGenerator;
 import com.faforever.neroxis.generator.texture.TextureGenerator;
 import com.faforever.neroxis.generator.texture.WindingRiverTextureGenerator;
@@ -66,7 +65,7 @@ public abstract class StyleGenerator implements HasParameterConstraints {
                 new WeightedOption<>(new MarsTextureGenerator(), 1f),
                 new WeightedOption<>(new PrayerTextureGenerator(), 1f),
                 new WeightedOption<>(new StonesTextureGenerator(), 1f),
-                new WeightedOption<>(new SunsetTextureGenerator(), 1f),
+                // new WeightedOption<>(new SunsetTextureGenerator(), 1f),
                 new WeightedOption<>(new SyrtisTextureGenerator(), 1f),
                 new WeightedOption<>(new WindingRiverTextureGenerator(), 1f),
                 new WeightedOption<>(new WonderTextureGenerator(), 1f),

--- a/generator/src/main/java/com/faforever/neroxis/generator/texture/LegacyTextureGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/texture/LegacyTextureGenerator.java
@@ -122,9 +122,9 @@ public abstract class LegacyTextureGenerator extends TextureGenerator {
             map.setTextureMasksScaled(map.getTextureMasksLow(), texturesLowMask.getFinalMask());
             map.setTextureMasksScaled(map.getTextureMasksHigh(), texturesHighMask.getFinalMask());
             map.setTerrainType(map.getTerrainType(), terrainType.getFinalMask());
-            map.setMapwideTexture(
-                    ImageUtil.getMapwideTexture(normals.getFinalMask(), scaledWaterDepth.getFinalMask(),
-                                                shadows.getFinalMask()));
+            map.setMapNormalTexture(ImageUtil.getMapNormalTexture(normals.getFinalMask()));
+            map.setMapInfoTexture(ImageUtil.getMapInfoTexture(scaledWaterDepth.getFinalMask(),
+                                                              shadows.getFinalMask()));
         });
     }
 }

--- a/generator/src/main/java/com/faforever/neroxis/generator/texture/PbrTextureGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/texture/PbrTextureGenerator.java
@@ -184,9 +184,9 @@ public abstract class PbrTextureGenerator extends TextureGenerator {
             map.setTextureMasksScaled(map.getTextureMasksLow(), texturesLowMask.getFinalMask());
             map.setTextureMasksScaled(map.getTextureMasksHigh(), texturesHighMask.getFinalMask());
             map.setTerrainType(map.getTerrainType(), terrainType.getFinalMask());
-            map.setMapwideTexture(
-                    ImageUtil.getMapwideTexture(normals.getFinalMask(), scaledWaterDepth.getFinalMask(),
-                                                shadows.getFinalMask()));
+            map.setMapNormalTexture(ImageUtil.getMapNormalTexture(normals.getFinalMask()));
+            map.setMapInfoTexture(ImageUtil.getMapInfoTexture(scaledWaterDepth.getFinalMask(),
+                                                              shadows.getFinalMask()));
             map.setWaterShadowMap(map.getWaterShadowMap(), waterSurfaceShadows.getFinalMask());
         });
     }

--- a/generator/src/main/java/com/faforever/neroxis/generator/texture/TextureGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/texture/TextureGenerator.java
@@ -79,9 +79,9 @@ public abstract class TextureGenerator implements HasParameterConstraints {
         DebugUtil.timedRun("com.faforever.neroxis.map.generator", "generateTextures", () -> {
             map.setTextureMasksScaled(map.getTextureMasksLow(), texturesLowMask.getFinalMask());
             map.setTextureMasksScaled(map.getTextureMasksHigh(), texturesHighMask.getFinalMask());
-            map.setMapwideTexture(
-                    ImageUtil.getMapwideTexture(normals.getFinalMask(), scaledWaterDepth.getFinalMask(),
-                                                shadows.getFinalMask()));
+            map.setMapNormalTexture(ImageUtil.getMapNormalTexture(normals.getFinalMask()));
+            map.setMapInfoTexture(ImageUtil.getMapInfoTexture(scaledWaterDepth.getFinalMask(),
+                                                              shadows.getFinalMask()));
         });
     }
 

--- a/generator/src/main/java/com/faforever/neroxis/generator/texture/TextureGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/texture/TextureGenerator.java
@@ -52,12 +52,11 @@ public abstract class TextureGenerator implements HasParameterConstraints {
         heightmap = terrainGenerator.getHeightmap();
         slope = terrainGenerator.getSlope();
 
-        FloatMask heightMapSize = heightmap.copy().resample(map.getSize());
-
-        normals = heightMapSize.copy()
+        normals = heightmap.copy()
                                .addGaussianNoise(.025f)
                                .blur(1)
-                               .copyAsNormalMask(2f);
+                               .copyAsNormalMask(1f);
+        FloatMask heightMapSize = heightmap.copy().resample(map.getSize());
         shadowsMask = heightMapSize
                 .copyAsShadowMask(biome.lightingSettings().sunDirection()).inflate(0.5f);
         shadows = shadowsMask.copyAsFloatMask(1, 0);

--- a/shared/src/main/java/com/faforever/neroxis/exporter/MapExporter.java
+++ b/shared/src/main/java/com/faforever/neroxis/exporter/MapExporter.java
@@ -23,7 +23,8 @@ public class MapExporter {
                     SCMapExporter.exportShadows(mapPath, map);
                 }
             } else if (map.getTerrainShaderPath().equals(PBR_SHADER_NAME)){
-                SCMapExporter.exportMapwideTexture(folderPath.resolve(map.getFolderName()), map);
+                SCMapExporter.exportMapInfoTexture(folderPath.resolve(map.getFolderName()), map);
+                SCMapExporter.exportMapNormalTexture(folderPath.resolve(map.getFolderName()), map);
                 SCMapExporter.exportPBR(folderPath.resolve(map.getFolderName()), map);
             }
             if (exportPreview) {

--- a/shared/src/main/java/com/faforever/neroxis/exporter/SCMapExporter.java
+++ b/shared/src/main/java/com/faforever/neroxis/exporter/SCMapExporter.java
@@ -46,8 +46,9 @@ import static com.faforever.neroxis.util.EndianSwapper.swap;
 import static com.faforever.neroxis.util.jsquish.Squish.compressImage;
 
 public class SCMapExporter {
-    public static final String PBR_DDS = "heightRoughness.dds";
-    public static final String MAPWIDE_DDS = "mapwide.dds";
+    public static final String PBR_DDS = "roughnessAndHeight.dds";
+    public static final String MAP_INFO_DDS = "mapInfo.dds";
+    public static final String MAP_NORMAL_DDS = "mapNormal.dds";
     public static File file;
     private static DataOutputStream out;
 
@@ -123,13 +124,19 @@ public class SCMapExporter {
             writeFloat(0);
         }
         for (int i = 0; i < TerrainMaterials.TERRAIN_TEXTURE_COUNT; i++) {
-            if (i == 9 && PBR_SHADER_NAME.equals(map.getTerrainShaderPath())) {
+            if (i == 8 && PBR_SHADER_NAME.equals(map.getTerrainShaderPath())) {
                 writeStringNull(Path.of("/maps", map.getFolderName(), "env",
-                                        "layers", "mapwide.dds")
+                                        "layers", MAP_INFO_DDS)
                                     .toString()
                                     .replace("\\", "/"));
                 writeFloat(map.getSize() + 1);
-            } else {
+            } else if (i == 9 && PBR_SHADER_NAME.equals(map.getTerrainShaderPath())) {
+                writeStringNull(Path.of("/maps", map.getFolderName(), "env",
+                                        "layers", PBR_DDS)
+                                    .toString()
+                                    .replace("\\", "/"));
+                writeFloat(map.getSize() + 1);
+            }else {
                 TerrainMaterials.TextureScale textureScale = mapTerrainMaterials.textures().get(i);
                 writeStringNull(textureScale.path());
                 writeFloat(textureScale.scale());
@@ -139,13 +146,14 @@ public class SCMapExporter {
             TerrainMaterials.TextureScale textureScale = mapTerrainMaterials.normals().get(i);
             if (i == 8 && PBR_SHADER_NAME.equals(map.getTerrainShaderPath())) {
                 writeStringNull(Path.of("/maps", map.getFolderName(), "env",
-                                        "layers", "heightRoughness.dds")
+                                        "layers", MAP_NORMAL_DDS)
                                     .toString()
                                     .replace("\\", "/"));
+                writeFloat(map.getSize() + 1);
             } else {
                 writeStringNull(textureScale.path());
+                writeFloat(textureScale.scale());
             }
-            writeFloat(textureScale.scale());
         }
 
         writeInt(0); // unknown
@@ -296,16 +304,29 @@ public class SCMapExporter {
         }
     }
 
-    public static void exportMapwideTexture(Path folderPath, SCMap map) throws IOException {
-        BufferedImage image = map.getMapwideTexture();
+    public static void exportMapInfoTexture(Path folderPath, SCMap map) throws IOException {
+        BufferedImage image = map.getMapInfoTexture();
         Path textureDirectory = Paths.get("env", "layers");
-        Path filePath = textureDirectory.resolve(MAPWIDE_DDS);
+        Path filePath = textureDirectory.resolve(MAP_INFO_DDS);
         Path writingPath = folderPath.resolve(filePath);
         Files.createDirectories(writingPath.getParent());
         try {
             ImageUtil.writeRawDDS(image, writingPath);
         } catch (IOException e) {
-            System.out.print("Could not write the map-wide texture\n" + e);
+            System.out.print("Could not write the map info texture\n" + e);
+        }
+    }
+
+    public static void exportMapNormalTexture(Path folderPath, SCMap map) throws IOException {
+        BufferedImage image = map.getMapNormalTexture();
+        Path textureDirectory = Paths.get("env", "layers");
+        Path filePath = textureDirectory.resolve(MAP_NORMAL_DDS);
+        Path writingPath = folderPath.resolve(filePath);
+        Files.createDirectories(writingPath.getParent());
+        try {
+            ImageUtil.writeRawDDS(image, writingPath);
+        } catch (IOException e) {
+            System.out.print("Could not write the map normal texture\n" + e);
         }
     }
 
@@ -315,7 +336,7 @@ public class SCMapExporter {
         Path outPath = folderPath.resolve(filePath);
 
         try (InputStream inputStream = Objects.requireNonNull(
-                SCMapExporter.class.getResourceAsStream("/images/heightRoughness.dds"))) {
+                SCMapExporter.class.getResourceAsStream("/images/" + PBR_DDS))) {
             Files.createDirectories(outPath.getParent());
             Files.copy(inputStream, outPath, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {

--- a/shared/src/main/java/com/faforever/neroxis/map/SCMap.java
+++ b/shared/src/main/java/com/faforever/neroxis/map/SCMap.java
@@ -32,7 +32,7 @@ import static com.faforever.neroxis.util.ImageUtil.scaleImage;
 @SuppressWarnings("unused")
 @Data
 public class SCMap {
-    public static final String PBR_SHADER_NAME = "Terrain301";
+    public static final String PBR_SHADER_NAME = "Terrain250";
     public static final String LEGACY_SHADER_NAME = "TTerrainXP";
     public static final int SIGNATURE = 443572557;
     public static final int VERSION_MAJOR = 2;
@@ -91,7 +91,8 @@ public class SCMap {
     private BufferedImage waterShadowMap;
     private BufferedImage waterDepthBiasMap;
     private BufferedImage terrainType;
-    private BufferedImage mapwideTexture;
+    private BufferedImage mapInfoTexture;
+    private BufferedImage mapNormalTexture;
     private int cartographicContourInterval = 100;
     private int cartographicDeepWaterColor = new Color(71, 140, 181).getRGB();
     private int cartographicMapContourColor = new Color(0, 0, 0).getRGB();
@@ -455,8 +456,10 @@ public class SCMap {
                                       StrictMath.round(textureMasksHigh.getHeight() * contentScale));
         textureMasksLow = scaleImage(textureMasksLow, StrictMath.round(textureMasksLow.getWidth() * contentScale),
                                      StrictMath.round(textureMasksLow.getHeight() * contentScale));
-        mapwideTexture = scaleImage(mapwideTexture, StrictMath.round(mapwideTexture.getWidth() * contentScale),
-                                    StrictMath.round(mapwideTexture.getHeight() * contentScale));
+        mapNormalTexture = scaleImage(mapNormalTexture, StrictMath.round(mapNormalTexture.getWidth() * contentScale),
+                                      StrictMath.round(mapNormalTexture.getHeight() * contentScale));
+        mapInfoTexture = scaleImage(mapInfoTexture, StrictMath.round(mapInfoTexture.getWidth() * contentScale),
+                                      StrictMath.round(mapInfoTexture.getHeight() * contentScale));
     }
 
     private void scaleBiome(float contentScale) {
@@ -489,7 +492,8 @@ public class SCMap {
         float waterMapScale = (float) waterMap.getWidth() / size;
         float textureMaskHighScale = (float) textureMasksHigh.getWidth() / size;
         float textureMaskLowScale = (float) textureMasksLow.getWidth() / size;
-        float mapwideTextureScale = (float) mapwideTexture.getWidth() / size;
+        float mapNormalTextureScale = (float) mapNormalTexture.getWidth() / size;
+        float mapInfoTextureScale = (float) mapInfoTexture.getWidth() / size;
         preview = scaleImage(preview, StrictMath.round(256 / boundsScale), StrictMath.round(256 / boundsScale));
         Vector2 previewOffset = boundsScale > 1 ? new Vector2(128 - 128 / boundsScale,
                                                               128 - 128 / boundsScale) : new Vector2(-64 / boundsScale,
@@ -529,10 +533,14 @@ public class SCMap {
                                                         StrictMath.round(textureMasksLow.getWidth() * boundsScale),
                                                         StrictMath.round(textureMasksLow.getHeight() * boundsScale),
                                                         topLeftOffset.multiply(textureMaskLowScale));
-        mapwideTexture = insertImageIntoNewImageOfSize(mapwideTexture,
-                                                       StrictMath.round(mapwideTexture.getWidth() * boundsScale),
-                                                       StrictMath.round(mapwideTexture.getHeight() * boundsScale),
-                                                       topLeftOffset.multiply(mapwideTextureScale));
+        mapNormalTexture = insertImageIntoNewImageOfSize(mapNormalTexture,
+                                                         StrictMath.round(mapNormalTexture.getWidth() * boundsScale),
+                                                         StrictMath.round(mapNormalTexture.getHeight() * boundsScale),
+                                                         topLeftOffset.multiply(mapNormalTextureScale));
+        mapInfoTexture = insertImageIntoNewImageOfSize(mapInfoTexture,
+                                                         StrictMath.round(mapInfoTexture.getWidth() * boundsScale),
+                                                         StrictMath.round(mapInfoTexture.getHeight() * boundsScale),
+                                                         topLeftOffset.multiply(mapInfoTextureScale));
     }
 
     private void moveObjects(float contentScale, Vector2 offset) {

--- a/shared/src/main/java/com/faforever/neroxis/mask/FloatMask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/FloatMask.java
@@ -206,8 +206,10 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
 
     Vector3 calculateNormalAt(int x, int y, float scale) {
         float xNormal, yNormal;
-        xNormal = (getPrimitive(x, y) - getPrimitive(x + 1, y)) * scale;
-        yNormal = (getPrimitive(x, y) - getPrimitive(x, y + 1)) * scale;
+        xNormal = ((getPrimitive(x, y) - getPrimitive(x + 1, y)) +
+                  (getPrimitive(x, y + 1) - getPrimitive(x + 1, y + 1))) * 0.5f * scale;
+        yNormal = ((getPrimitive(x, y) - getPrimitive(x, y + 1)) +
+                   (getPrimitive(x + 1, y) - getPrimitive(x + 1, y + 1))) * 0.5f * scale;
         return new Vector3(xNormal, 1, yNormal).normalize();
     }
 

--- a/shared/src/main/java/com/faforever/neroxis/mask/FloatMask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/FloatMask.java
@@ -206,20 +206,8 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
 
     Vector3 calculateNormalAt(int x, int y, float scale) {
         float xNormal, yNormal;
-        if (x == 0) {
-            xNormal = (getPrimitive(x, y) - getPrimitive(x + 1, y)) * scale;
-        } else if (x == (getSize() - 1)) {
-            xNormal = (getPrimitive(x - 1, y) - getPrimitive(x, y)) * scale;
-        } else {
-            xNormal = (getPrimitive(x - 1, y) - getPrimitive(x + 1, y)) * scale / 2f;
-        }
-        if (y == 0) {
-            yNormal = (getPrimitive(x, y) - getPrimitive(x, y + 1)) * scale;
-        } else if (y == (getSize() - 1)) {
-            yNormal = (getPrimitive(x, y - 1) - getPrimitive(x, y)) * scale;
-        } else {
-            yNormal = (getPrimitive(x, y - 1) - getPrimitive(x, y + 1)) * scale / 2f;
-        }
+        xNormal = (getPrimitive(x, y) - getPrimitive(x + 1, y)) * scale;
+        yNormal = (getPrimitive(x, y) - getPrimitive(x, y + 1)) * scale;
         return new Vector3(xNormal, 1, yNormal).normalize();
     }
 

--- a/shared/src/main/java/com/faforever/neroxis/mask/NormalMask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/NormalMask.java
@@ -35,8 +35,7 @@ public final class NormalMask extends VectorMask<Vector3, NormalMask> {
     }
 
     public NormalMask(FloatMask other, float scale, String name) {
-        this(other.getSize(), other.getNextSeed(), name, other.isParallel());
-        assertCompatibleMask(other);
+        this(other.getSize() - 1, other.getNextSeed(), name, other.isParallel());
         enqueue(dependencies -> {
             FloatMask source = (FloatMask) dependencies.getFirst();
             set((x, y) -> source.calculateNormalAt(x, y, scale));

--- a/shared/src/main/java/com/faforever/neroxis/util/ImageUtil.java
+++ b/shared/src/main/java/com/faforever/neroxis/util/ImageUtil.java
@@ -172,13 +172,13 @@ public class ImageUtil {
     }
 
     public static BufferedImage getMapInfoTexture(FloatMask waterDepth, FloatMask shadowMask) {
-        waterDepth.resample(shadowMask.getSize());
+        FloatMask waterDepthCopy = waterDepth.copy().resample(shadowMask.getSize());
         int size = shadowMask.getSize();
         BufferedImage image = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
         WritableRaster imageRaster = image.getRaster();
         for (int y = 0; y < size; y++) {
             for (int x = 0; x < size; x++) {
-                int xV = (byte) StrictMath.min(StrictMath.max(waterDepth.get(x, y) * 255, 0), 255);
+                int xV = (byte) StrictMath.min(StrictMath.max(waterDepthCopy.get(x, y) * 255, 0), 255);
                 int yV = (byte) 255;  // ambient occlusion channel
                 int wV = (byte) StrictMath.min(StrictMath.max(shadowMask.get(x, y) * 255, 0), 255);
                 imageRaster.setPixel(x, y, new int[]{xV, yV, yV, wV});

--- a/shared/src/main/java/com/faforever/neroxis/util/ImageUtil.java
+++ b/shared/src/main/java/com/faforever/neroxis/util/ImageUtil.java
@@ -171,23 +171,32 @@ public class ImageUtil {
         Files.write(path, imageBytes.array(), StandardOpenOption.APPEND);
     }
 
-    public static BufferedImage getMapwideTexture(NormalMask normalMask, FloatMask waterDepth, FloatMask shadowMask) {
-        if (shadowMask.getSize() != normalMask.getSize()) {
-            throw new IllegalArgumentException("Mask sizes do not match: shadow size %d, normal size %d"
-                                                       .formatted(shadowMask.getSize(), normalMask.getSize()));
-        }
+    public static BufferedImage getMapInfoTexture(FloatMask waterDepth, FloatMask shadowMask) {
         waterDepth.resample(shadowMask.getSize());
         int size = shadowMask.getSize();
         BufferedImage image = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
         WritableRaster imageRaster = image.getRaster();
         for (int y = 0; y < size; y++) {
             for (int x = 0; x < size; x++) {
+                int xV = (byte) StrictMath.min(StrictMath.max(waterDepth.get(x, y) * 255, 0), 255);
+                int yV = (byte) 255;  // ambient occlusion channel
+                int wV = (byte) StrictMath.min(StrictMath.max(shadowMask.get(x, y) * 255, 0), 255);
+                imageRaster.setPixel(x, y, new int[]{xV, yV, yV, wV});
+            }
+        }
+        return image;
+    }
+
+    public static BufferedImage getMapNormalTexture(NormalMask normalMask) {
+        int size = normalMask.getSize();
+        BufferedImage image = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
+        WritableRaster imageRaster = image.getRaster();
+        for (int y = 0; y < size; y++) {
+            for (int x = 0; x < size; x++) {
                 Vector3 normalValue = normalMask.get(x, y);
                 int xV = (byte) StrictMath.min(StrictMath.max(128 * normalValue.x() + 127, 0), 255);
-                int yV = (byte) StrictMath.min(StrictMath.max(128 * normalValue.z() + 127, 0), 255);
-                int zV = (byte) StrictMath.min(StrictMath.max(waterDepth.get(x, y) * 255, 0), 255);
-                int wV = (byte) StrictMath.min(StrictMath.max(shadowMask.get(x, y) * 255, 0), 255);
-                imageRaster.setPixel(x, y, new int[]{xV, yV, zV, wV});
+                int zV = (byte) StrictMath.min(StrictMath.max(128 * normalValue.z() + 127, 0), 255);
+                imageRaster.setPixel(x, y, new int[]{zV, zV, zV, xV});
             }
         }
         return image;

--- a/shared/src/main/resources/custom_biome/Sunset/materials.json
+++ b/shared/src/main/resources/custom_biome/Sunset/materials.json
@@ -43,11 +43,11 @@
       "scale": 4.92
     },
     {
-      "path": "/env/Evergreen/layers/macrotexture000_albedo.dds",
-      "scale": 77.5
+      "path": "map/env/layers/mapInfo.dds",
+      "scale": 1.0
     },
     {
-      "path": "map/env/layers/mapwide.dds",
+      "path": "map/env/layers/roughnessAndHeight.dds",
       "scale": 1.0
     }
   ],
@@ -85,7 +85,7 @@
       "scale": 15.1
     },
     {
-      "path": "map/env/layers/heightRoughness.dds",
+      "path": "map/env/layers/mapNormal.dds",
       "scale": 1.0
     }
   ],

--- a/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/MapEnvTextureExporter.java
+++ b/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/MapEnvTextureExporter.java
@@ -1,5 +1,6 @@
 package com.faforever.neroxis.toolsuite;
 
+import com.faforever.neroxis.cli.DebugMixin;
 import com.faforever.neroxis.cli.RequiredMapPathMixin;
 import com.faforever.neroxis.cli.VersionProvider;
 import com.faforever.neroxis.exporter.SCMapExporter;
@@ -23,6 +24,8 @@ public class MapEnvTextureExporter implements Callable<Integer> {
     private CommandLine.Model.CommandSpec spec;
     @CommandLine.Mixin
     private RequiredMapPathMixin requiredMapPathMixin;
+    @CommandLine.Mixin
+    private DebugMixin debugMixin;
 
     @Override
     public Integer call() throws Exception {

--- a/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/MapEnvTextureExporter.java
+++ b/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/MapEnvTextureExporter.java
@@ -35,10 +35,10 @@ public class MapEnvTextureExporter implements Callable<Integer> {
         SCMap map = MapImporter.importMap(requiredMapPathMixin.getMapPath());
 
         FloatMask heightMap = new FloatMask(map.getHeightmap(), (long) 0, new SymmetrySettings(Symmetry.NONE))
-                .resample(map.getSize())
                 .divide(128f); // The scmap binary scales by 128
-        NormalMask normals = heightMap.copyAsNormalMask(2f);
+        NormalMask normals = heightMap.copyAsNormalMask(1f);
 
+        heightMap.resample(map.getSize());
         BooleanMask realLand = heightMap.copyAsBooleanMask(map.getBiome().waterSettings().elevation());
         BooleanMask realWater = realLand.copy().invert();
         BooleanMask shadowsMask = heightMap

--- a/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/MapEnvTextureExporter.java
+++ b/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/MapEnvTextureExporter.java
@@ -3,7 +3,7 @@ package com.faforever.neroxis.toolsuite;
 import com.faforever.neroxis.cli.RequiredMapPathMixin;
 import com.faforever.neroxis.cli.VersionProvider;
 import com.faforever.neroxis.exporter.SCMapExporter;
-import com.faforever.neroxis.importer.MapImporter;
+import com.faforever.neroxis.importer.SCMapImporter;
 import com.faforever.neroxis.map.SCMap;
 import com.faforever.neroxis.map.Symmetry;
 import com.faforever.neroxis.map.SymmetrySettings;
@@ -32,7 +32,7 @@ public class MapEnvTextureExporter implements Callable<Integer> {
 
     public void generateEnvTexture() throws Exception {
         System.out.print("Generating env texture\n");
-        SCMap map = MapImporter.importMap(requiredMapPathMixin.getMapPath());
+        SCMap map = SCMapImporter.importSCMAP(requiredMapPathMixin.getMapPath());
 
         FloatMask heightMap = new FloatMask(map.getHeightmap(), (long) 0, new SymmetrySettings(Symmetry.NONE))
                 .divide(128f); // The scmap binary scales by 128

--- a/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/MapInfoTextureExporter.java
+++ b/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/MapInfoTextureExporter.java
@@ -10,16 +10,15 @@ import com.faforever.neroxis.map.Symmetry;
 import com.faforever.neroxis.map.SymmetrySettings;
 import com.faforever.neroxis.mask.BooleanMask;
 import com.faforever.neroxis.mask.FloatMask;
-import com.faforever.neroxis.mask.NormalMask;
 import com.faforever.neroxis.util.ImageUtil;
 import picocli.CommandLine;
 
 import java.util.concurrent.Callable;
 
-@CommandLine.Command(name = "export-env-map", mixinStandardHelpOptions = true,
-                     description = "Export the mapwide normal, waterDepth and shadow texture",
+@CommandLine.Command(name = "export-map-info", mixinStandardHelpOptions = true,
+                     description = "Export the map info texture containing waterDepth, shadows, and ambient occlusion.",
                      versionProvider = VersionProvider.class, usageHelpAutoWidth = true)
-public class MapEnvTextureExporter implements Callable<Integer> {
+public class MapInfoTextureExporter implements Callable<Integer> {
     @CommandLine.Spec
     private CommandLine.Model.CommandSpec spec;
     @CommandLine.Mixin
@@ -29,17 +28,16 @@ public class MapEnvTextureExporter implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
-        generateEnvTexture();
+        generateMapInfoTexture();
         return 0;
     }
 
-    public void generateEnvTexture() throws Exception {
-        System.out.print("Generating env texture\n");
+    public void generateMapInfoTexture() throws Exception {
+        System.out.print("Generating map info texture\n");
         SCMap map = SCMapImporter.importSCMAP(requiredMapPathMixin.getMapPath());
 
         FloatMask heightMap = new FloatMask(map.getHeightmap(), (long) 0, new SymmetrySettings(Symmetry.NONE))
                 .divide(128f); // The scmap binary scales by 128
-        NormalMask normals = heightMap.copyAsNormalMask(1f);
 
         heightMap.resample(map.getSize());
         BooleanMask realLand = heightMap.copyAsBooleanMask(map.getBiome().waterSettings().elevation());
@@ -63,7 +61,7 @@ public class MapEnvTextureExporter implements Callable<Integer> {
                                               .clampMin(0f)
                                               .clampMax(1f);
 
-        map.setMapwideTexture(ImageUtil.getMapwideTexture(normals, scaledWaterDepth, shadows));
-        SCMapExporter.exportMapwideTexture(requiredMapPathMixin.getMapPath(), map);
+        map.setMapInfoTexture(ImageUtil.getMapInfoTexture(scaledWaterDepth, shadows));
+        SCMapExporter.exportMapInfoTexture(requiredMapPathMixin.getMapPath(), map);
     }
 }

--- a/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/MapNormalsTextureExporter.java
+++ b/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/MapNormalsTextureExporter.java
@@ -1,0 +1,46 @@
+package com.faforever.neroxis.toolsuite;
+
+import com.faforever.neroxis.cli.DebugMixin;
+import com.faforever.neroxis.cli.RequiredMapPathMixin;
+import com.faforever.neroxis.cli.VersionProvider;
+import com.faforever.neroxis.exporter.SCMapExporter;
+import com.faforever.neroxis.importer.SCMapImporter;
+import com.faforever.neroxis.map.SCMap;
+import com.faforever.neroxis.map.Symmetry;
+import com.faforever.neroxis.map.SymmetrySettings;
+import com.faforever.neroxis.mask.FloatMask;
+import com.faforever.neroxis.mask.NormalMask;
+import com.faforever.neroxis.util.ImageUtil;
+import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
+
+@CommandLine.Command(name = "export-map-normals", mixinStandardHelpOptions = true,
+        description = "Export the map normal texture.",
+        versionProvider = VersionProvider.class, usageHelpAutoWidth = true)
+public class MapNormalsTextureExporter implements Callable<Integer> {
+    @CommandLine.Spec
+    private CommandLine.Model.CommandSpec spec;
+    @CommandLine.Mixin
+    private RequiredMapPathMixin requiredMapPathMixin;
+    @CommandLine.Mixin
+    private DebugMixin debugMixin;
+
+    @Override
+    public Integer call() throws Exception {
+        generateMapNormalTexture();
+        return 0;
+    }
+
+    public void generateMapNormalTexture() throws Exception {
+        System.out.print("Generating map normal texture\n");
+        SCMap map = SCMapImporter.importSCMAP(requiredMapPathMixin.getMapPath());
+
+        FloatMask heightMap = new FloatMask(map.getHeightmap(), (long) 0, new SymmetrySettings(Symmetry.NONE))
+                .divide(128f); // The scmap binary scales by 128
+        NormalMask normals = heightMap.copyAsNormalMask(1f);
+
+        map.setMapNormalTexture(ImageUtil.getMapNormalTexture(normals));
+        SCMapExporter.exportMapNormalTexture(requiredMapPathMixin.getMapPath(), map);
+    }
+}

--- a/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/MapToolSuite.java
+++ b/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/MapToolSuite.java
@@ -6,7 +6,7 @@ import picocli.CommandLine;
 import static picocli.CommandLine.Command;
 
 @Command(name = "maptools", mixinStandardHelpOptions = true, description = "Tools to modify maps", versionProvider = VersionProvider.class, usageHelpAutoWidth = true, synopsisSubcommandLabel = "COMMAND", subcommands = {
-        MapPopulator.class, MapResizer.class, MapStratumResizer.class, MapForcer.class, MapEvaluator.class, MapEnvTextureExporter.class, PbrTextureGenerator.class})
+        MapPopulator.class, MapResizer.class, MapStratumResizer.class, MapForcer.class, MapEvaluator.class, MapInfoTextureExporter.class, PbrTextureGenerator.class})
 public class MapToolSuite {
     private MapToolSuite() {
     }

--- a/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/MapToolSuite.java
+++ b/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/MapToolSuite.java
@@ -6,7 +6,7 @@ import picocli.CommandLine;
 import static picocli.CommandLine.Command;
 
 @Command(name = "maptools", mixinStandardHelpOptions = true, description = "Tools to modify maps", versionProvider = VersionProvider.class, usageHelpAutoWidth = true, synopsisSubcommandLabel = "COMMAND", subcommands = {
-        MapPopulator.class, MapResizer.class, MapStratumResizer.class, MapForcer.class, MapEvaluator.class, MapInfoTextureExporter.class, PbrTextureGenerator.class})
+        MapPopulator.class, MapResizer.class, MapStratumResizer.class, MapForcer.class, MapEvaluator.class, MapInfoTextureExporter.class, MapNormalsTextureExporter.class, PbrTextureGenerator.class})
 public class MapToolSuite {
     private MapToolSuite() {
     }

--- a/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/PbrTextureGenerator.java
+++ b/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/PbrTextureGenerator.java
@@ -28,19 +28,10 @@ public class PbrTextureGenerator implements Callable<Integer> {
     private CommandLine.Model.CommandSpec spec;
     @CommandLine.Mixin
     private DebugMixin debugMixin;
-    private Integer textureImageSize;
     @Getter
     private Path inputPath;
     @Getter
     private Path outputPath;
-
-    @CommandLine.Option(names = "--size", defaultValue = "1024", description = "Size of the input textures in pixels. Defaults to 1024.")
-    public void setTextureImageSize(int size) {
-        if (!isPowerOfTwo(size)) {
-            throw new CommandLine.ParameterException(spec.commandLine(), "Texture size must be a power of two!");
-        }
-        textureImageSize = size;
-    }
 
     @CommandLine.Option(names = {"--in-path"}, description = "Folder with input images. Defaults to the working directory.", defaultValue = ".")
     public void setInputPath(Path inputPath) {
@@ -54,6 +45,10 @@ public class PbrTextureGenerator implements Callable<Integer> {
         this.outputPath = outputPath;
     }
 
+    private int inputImageSize = 0;
+    private Vector4Mask pbrMask;
+    private int offset;
+
     @Override
     public Integer call() throws Exception {
         generatePbrTexture();
@@ -61,20 +56,9 @@ public class PbrTextureGenerator implements Callable<Integer> {
     }
     
     SymmetrySettings noSymmetry = new SymmetrySettings(Symmetry.NONE);
-
-    public boolean isPowerOfTwo(int number) {
-        if(number <=0){
-            return false;
-        }
-        return (number & -number) == number;
-    }
     
     public void generatePbrTexture() throws Exception {
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(getInputPath())) {
-            int pbrTextureSize = textureImageSize * 4;
-            int offset = pbrTextureSize / 2;
-            Vector4Mask pbrMask = new Vector4Mask(pbrTextureSize, 0L, noSymmetry);
-            BufferedImage pbrTexture = new BufferedImage(pbrTextureSize, pbrTextureSize, BufferedImage.TYPE_INT_ARGB);
             int filesProcessed = 0;
             for (Path path : stream) {
                 if (Files.isRegularFile(path)) {
@@ -86,11 +70,7 @@ public class PbrTextureGenerator implements Callable<Integer> {
                         int layer = Integer.parseInt(numberStr);
                         if (path.getFileName().toString().toLowerCase().startsWith("roughness")) {
                             System.out.printf("Reading roughness texture %s\n", path.getFileName());
-                            if (image.getHeight() != textureImageSize) {
-                                throw new RuntimeException("Wrong texture size! Expected " + textureImageSize + ", but is " + image.getHeight() + ". " +
-                                                           "All textures must be the same size. " +
-                                                           "Don't forget to use the --size option if your textures are not 1024 px.");
-                            }
+                            validateSize(image.getHeight());
                             FloatMask roughness = createOffsetMaskFromImage(image);
                             int component = (layer >= 4) ? 3 : 1;
                             int xOffset = (layer % 2 == 1) ? offset : 0;
@@ -99,11 +79,7 @@ public class PbrTextureGenerator implements Callable<Integer> {
                             filesProcessed++;
                         } else if (path.getFileName().toString().toLowerCase().startsWith("height")) {
                             System.out.printf("Reading height texture %s\n", path.getFileName());
-                            if (image.getHeight() != textureImageSize) {
-                                throw new RuntimeException("Wrong texture size! Expected " + textureImageSize + ", but is " + image.getHeight() + ". " +
-                                                           "All textures must be the same size. " +
-                                                           "Don't forget to use the --size option if your textures are not 1024 px.");
-                            }
+                            validateSize(image.getHeight());
                             FloatMask height = createOffsetMaskFromImage(image);
                             int component = (layer >= 4) ? 2 : 0;
                             int xOffset = (layer % 2 == 1) ? offset : 0;
@@ -119,13 +95,26 @@ public class PbrTextureGenerator implements Callable<Integer> {
                         "The files need to be named 'RoughnessX' or 'HeightX' where X is the number " +
                         "that specifies the texture layer.");
             }
+            BufferedImage pbrTexture = new BufferedImage(inputImageSize * 4, inputImageSize * 4, BufferedImage.TYPE_INT_ARGB);
             pbrMask.writeToImage(pbrTexture);
             Path textureDirectory = getOutputPath();
             Path filePath = textureDirectory.resolve("heightRoughness.dds");
             System.out.printf("Processed %d files.\n", filesProcessed);
-            System.out.print("Compressing dds texture. This will probably take a while...\n");
+            System.out.print("Compressing dds texture. This can take over a minute...\n");
             ImageUtil.writeCompressedDDS(pbrTexture, filePath);
             System.out.print("Successfully wrote dds output\n");
+        }
+    }
+
+    private void validateSize(int imageSize) {
+        if (inputImageSize == 0) {
+            inputImageSize = imageSize;
+            offset = imageSize * 2;
+            pbrMask = new Vector4Mask(imageSize * 4, 0L, noSymmetry);
+        } else if (imageSize != inputImageSize) {
+            throw new RuntimeException("Wrong texture size! Expected " + inputImageSize
+                                       + ", but is " + imageSize + ". " +
+                                       "All textures must be the same size.");
         }
     }
 

--- a/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/PbrTextureGenerator.java
+++ b/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/PbrTextureGenerator.java
@@ -16,6 +16,7 @@ import java.awt.image.BufferedImage;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -32,6 +33,8 @@ public class PbrTextureGenerator implements Callable<Integer> {
     private Path inputPath;
     @Getter
     private Path outputPath;
+    @Getter
+    private String compression;
 
     @CommandLine.Option(names = {"--in-path"}, description = "Folder with input images. Defaults to the working directory.", defaultValue = ".")
     public void setInputPath(Path inputPath) {
@@ -43,6 +46,11 @@ public class PbrTextureGenerator implements Callable<Integer> {
     public void setOutputPath(Path outputPath) {
         CLIUtils.checkWritableDirectory(outputPath, spec);
         this.outputPath = outputPath;
+    }
+
+    @CommandLine.Option(names = {"--compression"}, description = "Compression of the dds file. Available options are DXT5 and None. Defaults to DXT5", defaultValue = "DXT5")
+    public void setCompression(String compression) {
+        this.compression = compression;
     }
 
     private int inputImageSize = 0;
@@ -100,8 +108,13 @@ public class PbrTextureGenerator implements Callable<Integer> {
             Path textureDirectory = getOutputPath();
             Path filePath = textureDirectory.resolve("roughnessAndHeight.dds");
             System.out.printf("Processed %d files.\n", filesProcessed);
-            System.out.print("Compressing dds texture. This can take over a minute...\n");
-            ImageUtil.writeCompressedDDS(pbrTexture, filePath);
+            if (Objects.equals(compression, "None")) {
+                System.out.print("Writing dds texture.\n");
+                ImageUtil.writeRawDDS(pbrTexture, filePath);
+            } else {
+                System.out.print("Compressing dds texture. This can take over a minute...\n");
+                ImageUtil.writeCompressedDDS(pbrTexture, filePath);
+            }
             System.out.print("Successfully wrote dds output\n");
         }
     }

--- a/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/PbrTextureGenerator.java
+++ b/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/PbrTextureGenerator.java
@@ -1,6 +1,7 @@
 package com.faforever.neroxis.toolsuite;
 
 import com.faforever.neroxis.cli.CLIUtils;
+import com.faforever.neroxis.cli.DebugMixin;
 import com.faforever.neroxis.cli.VersionProvider;
 import com.faforever.neroxis.map.Symmetry;
 import com.faforever.neroxis.map.SymmetrySettings;
@@ -25,6 +26,8 @@ import java.util.regex.Pattern;
 public class PbrTextureGenerator implements Callable<Integer> {
     @CommandLine.Spec
     private CommandLine.Model.CommandSpec spec;
+    @CommandLine.Mixin
+    private DebugMixin debugMixin;
     private Integer textureImageSize;
     @Getter
     private Path inputPath;

--- a/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/PbrTextureGenerator.java
+++ b/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/PbrTextureGenerator.java
@@ -72,7 +72,7 @@ public class PbrTextureGenerator implements Callable<Integer> {
                             System.out.printf("Reading roughness texture %s\n", path.getFileName());
                             validateSize(image.getHeight());
                             FloatMask roughness = createOffsetMaskFromImage(image);
-                            int component = (layer >= 4) ? 3 : 1;
+                            int component = (layer >= 4) ? 2 : 0;
                             int xOffset = (layer % 2 == 1) ? offset : 0;
                             int yOffset = (layer % 4 >= 2) ? offset : 0;
                             pbrMask.setComponentWithOffset(roughness, component, xOffset, yOffset, false, false);
@@ -81,7 +81,7 @@ public class PbrTextureGenerator implements Callable<Integer> {
                             System.out.printf("Reading height texture %s\n", path.getFileName());
                             validateSize(image.getHeight());
                             FloatMask height = createOffsetMaskFromImage(image);
-                            int component = (layer >= 4) ? 2 : 0;
+                            int component = (layer >= 4) ? 3 : 1;
                             int xOffset = (layer % 2 == 1) ? offset : 0;
                             int yOffset = (layer % 4 >= 2) ? offset : 0;
                             pbrMask.setComponentWithOffset(height, component, xOffset, yOffset, false, false);
@@ -98,7 +98,7 @@ public class PbrTextureGenerator implements Callable<Integer> {
             BufferedImage pbrTexture = new BufferedImage(inputImageSize * 4, inputImageSize * 4, BufferedImage.TYPE_INT_ARGB);
             pbrMask.writeToImage(pbrTexture);
             Path textureDirectory = getOutputPath();
-            Path filePath = textureDirectory.resolve("heightRoughness.dds");
+            Path filePath = textureDirectory.resolve("roughnessAndHeight.dds");
             System.out.printf("Processed %d files.\n", filesProcessed);
             System.out.print("Compressing dds texture. This can take over a minute...\n");
             ImageUtil.writeCompressedDDS(pbrTexture, filePath);

--- a/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/PbrTextureGenerator.java
+++ b/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/PbrTextureGenerator.java
@@ -70,13 +70,14 @@ public class PbrTextureGenerator implements Callable<Integer> {
             int filesProcessed = 0;
             for (Path path : stream) {
                 if (Files.isRegularFile(path)) {
-                    Pattern pattern = Pattern.compile("\\d+");
-                    Matcher matcher = pattern.matcher(path.toFile().getName());
-                    if (matcher.find()) {
+                    Pattern pattern = Pattern.compile(".*(roughness|displacement|height)(\\d).*");
+                    String filename = path.getFileName().toString().toLowerCase();
+                    Matcher matcher = pattern.matcher(filename);
+                    if (matcher.matches()) {
                         BufferedImage image = ImageIO.read(path.toFile());
-                        String numberStr = matcher.group();
-                        int layer = Integer.parseInt(numberStr);
-                        if (path.getFileName().toString().toLowerCase().startsWith("roughness")) {
+                        String type = matcher.group(1);
+                        int layer = Integer.parseInt(matcher.group(2));
+                        if (Objects.equals(type, "roughness")) {
                             System.out.printf("Reading roughness texture %s\n", path.getFileName());
                             validateSize(image.getHeight());
                             FloatMask roughness = createOffsetMaskFromImage(image);
@@ -85,7 +86,7 @@ public class PbrTextureGenerator implements Callable<Integer> {
                             int yOffset = (layer % 4 >= 2) ? offset : 0;
                             pbrMask.setComponentWithOffset(roughness, component, xOffset, yOffset, false, false);
                             filesProcessed++;
-                        } else if (path.getFileName().toString().toLowerCase().startsWith("height")) {
+                        } else if (Objects.equals(type, "height") || Objects.equals(type, "displacement")) {
                             System.out.printf("Reading height texture %s\n", path.getFileName());
                             validateSize(image.getHeight());
                             FloatMask height = createOffsetMaskFromImage(image);
@@ -100,8 +101,8 @@ public class PbrTextureGenerator implements Callable<Integer> {
             }
             if (filesProcessed == 0) {
                 throw new RuntimeException("No files found to write into the pbr texture. " +
-                        "The files need to be named 'RoughnessX' or 'HeightX' where X is the number " +
-                        "that specifies the texture layer.");
+                        "The files need to have 'RoughnessX', 'HeightX' or 'DisplacementX' in their name, " +
+                        "where X is the number that specifies the texture layer.");
             }
             BufferedImage pbrTexture = new BufferedImage(inputImageSize * 4, inputImageSize * 4, BufferedImage.TYPE_INT_ARGB);
             pbrMask.writeToImage(pbrTexture);


### PR DESCRIPTION
I had to rework how the new shaders work in the game. This has implications for the functionality of the toolsuite and the current sunset biome that uses them.
This requires to temporarily disable the sunset biome. If we didn't do this then we would have to release the new map generator and the game patch at exactly the same time, or maps using the sunset biome would be temporarily broken. After the game patch we can enable the biome again.