### PR TITLE
Multiple Octive Perlin Noise, Terrain Generator

### DIFF
--- a/generator/src/main/java/com/faforever/neroxis/generator/MapStyle.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/MapStyle.java
@@ -4,12 +4,14 @@ import com.faforever.neroxis.generator.style.BasicStyleGenerator;
 import com.faforever.neroxis.generator.style.BigIslandsStyleGenerator;
 import com.faforever.neroxis.generator.style.CenterLakeStyleGenerator;
 import com.faforever.neroxis.generator.style.DropPlateauStyleGenerator;
+import com.faforever.neroxis.generator.style.FloodedMultiLevelStyleGenerator;
 import com.faforever.neroxis.generator.style.FloodedStyleGenerator;
 import com.faforever.neroxis.generator.style.HighReclaimStyleGenerator;
 import com.faforever.neroxis.generator.style.LandBridgeStyleGenerator;
 import com.faforever.neroxis.generator.style.LittleMountainStyleGenerator;
 import com.faforever.neroxis.generator.style.LowMexStyleGenerator;
 import com.faforever.neroxis.generator.style.MountainRangeStyleGenerator;
+import com.faforever.neroxis.generator.style.MultiLevelStyleGenerator;
 import com.faforever.neroxis.generator.style.OneIslandStyleGenerator;
 import com.faforever.neroxis.generator.style.RiversAndOceansStyleGenerator;
 import com.faforever.neroxis.generator.style.RiversStyleGenerator;
@@ -34,6 +36,8 @@ public enum MapStyle {
     LITTLE_MOUNTAIN(LittleMountainStyleGenerator.class, LittleMountainStyleGenerator::new, 1),
     LOW_MEX(LowMexStyleGenerator.class, LowMexStyleGenerator::new, .5f),
     MOUNTAIN_RANGE(MountainRangeStyleGenerator.class, MountainRangeStyleGenerator::new, 1),
+    MULTILEVEL(MultiLevelStyleGenerator.class, MultiLevelStyleGenerator::new, 1),
+    FLOODED_MULTILEVEL(FloodedMultiLevelStyleGenerator.class, FloodedMultiLevelStyleGenerator::new, 1),
     ONE_ISLAND(OneIslandStyleGenerator.class, OneIslandStyleGenerator::new, 1),
     SMALL_ISLANDS(SmallIslandsStyleGenerator.class, SmallIslandsStyleGenerator::new, 4),
     VALLEY(ValleyStyleGenerator.class, ValleyStyleGenerator::new, 1),

--- a/generator/src/main/java/com/faforever/neroxis/generator/resource/RiversAndOceansMexResourceGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/resource/RiversAndOceansMexResourceGenerator.java
@@ -4,7 +4,7 @@ public class RiversAndOceansMexResourceGenerator extends BasicResourceGenerator 
 
     @Override
     public void setupPipeline() {
-        resourceMask.init(passableLand).startVisualDebugger();
+        resourceMask.init(passableLand);
         resourceMask.add(passableWater
                                  .copy()
                                  .acid(random.nextFloat(0.3f, 0.7f), 0)

--- a/generator/src/main/java/com/faforever/neroxis/generator/resource/RiversAndOceansMexResourceGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/resource/RiversAndOceansMexResourceGenerator.java
@@ -4,8 +4,11 @@ public class RiversAndOceansMexResourceGenerator extends BasicResourceGenerator 
 
     @Override
     public void setupPipeline() {
-        resourceMask.init(passableLand);
-        resourceMask.add(passableWater);
+        resourceMask.init(passableLand).startVisualDebugger();
+        resourceMask.add(passableWater
+                                 .copy()
+                                 .acid(random.nextFloat(0.3f, 0.7f), 0)
+                                 .erode(random.nextFloat(0.5f,0.7f)));
         resourceMask.subtract(unbuildable);
         waterResourceMask.init(resourceMask);
     }

--- a/generator/src/main/java/com/faforever/neroxis/generator/style/FloodedMultiLevelStyleGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/style/FloodedMultiLevelStyleGenerator.java
@@ -1,6 +1,17 @@
 package com.faforever.neroxis.generator.style;
 
+import com.faforever.neroxis.generator.WeightedOption;
 import com.faforever.neroxis.generator.WeightedOptionsWithFallback;
+import com.faforever.neroxis.generator.prop.BasicPropGenerator;
+import com.faforever.neroxis.generator.prop.BoulderFieldPropGenerator;
+import com.faforever.neroxis.generator.prop.EnemyCivPropGenerator;
+import com.faforever.neroxis.generator.prop.HighReclaimPropGenerator;
+import com.faforever.neroxis.generator.prop.LargeBattlePropGenerator;
+import com.faforever.neroxis.generator.prop.NavyWrecksPropGenerator;
+import com.faforever.neroxis.generator.prop.NeutralCivPropGenerator;
+import com.faforever.neroxis.generator.prop.PropGenerator;
+import com.faforever.neroxis.generator.prop.RockFieldPropGenerator;
+import com.faforever.neroxis.generator.prop.SmallBattlePropGenerator;
 import com.faforever.neroxis.generator.resource.ResourceGenerator;
 import com.faforever.neroxis.generator.resource.RiversAndOceansMexResourceGenerator;
 import com.faforever.neroxis.generator.terrain.FloodedMultiLevelTerrainGenerator;
@@ -15,5 +26,19 @@ public class FloodedMultiLevelStyleGenerator extends StyleGenerator {
     @Override
     protected WeightedOptionsWithFallback<ResourceGenerator> getResourceGeneratorOptions() {
         return WeightedOptionsWithFallback.of(new RiversAndOceansMexResourceGenerator());
+    }
+
+    @Override
+    protected WeightedOptionsWithFallback<PropGenerator> getPropGeneratorOptions() {
+        return WeightedOptionsWithFallback.of(new BasicPropGenerator(),
+                                              new WeightedOption<>(new BasicPropGenerator(), 1f),
+                                              new WeightedOption<>(new BoulderFieldPropGenerator(), .1f),
+                                              new WeightedOption<>(new EnemyCivPropGenerator(), .5f),
+                                              new WeightedOption<>(new HighReclaimPropGenerator(), .25f),
+                                              new WeightedOption<>(new LargeBattlePropGenerator(), .5f),
+                                              new WeightedOption<>(new NavyWrecksPropGenerator(), 2f),
+                                              new WeightedOption<>(new NeutralCivPropGenerator(), 1f),
+                                              new WeightedOption<>(new RockFieldPropGenerator(), 1f),
+                                              new WeightedOption<>(new SmallBattlePropGenerator(), 1f));
     }
 }

--- a/generator/src/main/java/com/faforever/neroxis/generator/style/FloodedMultiLevelStyleGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/style/FloodedMultiLevelStyleGenerator.java
@@ -1,6 +1,8 @@
 package com.faforever.neroxis.generator.style;
 
 import com.faforever.neroxis.generator.WeightedOptionsWithFallback;
+import com.faforever.neroxis.generator.resource.ResourceGenerator;
+import com.faforever.neroxis.generator.resource.RiversAndOceansMexResourceGenerator;
 import com.faforever.neroxis.generator.terrain.FloodedMultiLevelTerrainGenerator;
 import com.faforever.neroxis.generator.terrain.TerrainGenerator;
 
@@ -8,5 +10,10 @@ public class FloodedMultiLevelStyleGenerator extends StyleGenerator {
     @Override
     protected WeightedOptionsWithFallback<TerrainGenerator> getTerrainGeneratorOptions() {
         return WeightedOptionsWithFallback.of(new FloodedMultiLevelTerrainGenerator());
+    }
+
+    @Override
+    protected WeightedOptionsWithFallback<ResourceGenerator> getResourceGeneratorOptions() {
+        return WeightedOptionsWithFallback.of(new RiversAndOceansMexResourceGenerator());
     }
 }

--- a/generator/src/main/java/com/faforever/neroxis/generator/style/FloodedMultiLevelStyleGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/style/FloodedMultiLevelStyleGenerator.java
@@ -1,0 +1,12 @@
+package com.faforever.neroxis.generator.style;
+
+import com.faforever.neroxis.generator.WeightedOptionsWithFallback;
+import com.faforever.neroxis.generator.terrain.FloodedMultiLevelTerrainGenerator;
+import com.faforever.neroxis.generator.terrain.TerrainGenerator;
+
+public class FloodedMultiLevelStyleGenerator extends StyleGenerator {
+    @Override
+    protected WeightedOptionsWithFallback<TerrainGenerator> getTerrainGeneratorOptions() {
+        return WeightedOptionsWithFallback.of(new FloodedMultiLevelTerrainGenerator());
+    }
+}

--- a/generator/src/main/java/com/faforever/neroxis/generator/style/MultiLevelStyleGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/style/MultiLevelStyleGenerator.java
@@ -1,6 +1,17 @@
 package com.faforever.neroxis.generator.style;
 
+import com.faforever.neroxis.generator.WeightedOption;
 import com.faforever.neroxis.generator.WeightedOptionsWithFallback;
+import com.faforever.neroxis.generator.prop.BasicPropGenerator;
+import com.faforever.neroxis.generator.prop.BoulderFieldPropGenerator;
+import com.faforever.neroxis.generator.prop.EnemyCivPropGenerator;
+import com.faforever.neroxis.generator.prop.HighReclaimPropGenerator;
+import com.faforever.neroxis.generator.prop.LargeBattlePropGenerator;
+import com.faforever.neroxis.generator.prop.NavyWrecksPropGenerator;
+import com.faforever.neroxis.generator.prop.NeutralCivPropGenerator;
+import com.faforever.neroxis.generator.prop.PropGenerator;
+import com.faforever.neroxis.generator.prop.RockFieldPropGenerator;
+import com.faforever.neroxis.generator.prop.SmallBattlePropGenerator;
 import com.faforever.neroxis.generator.terrain.MultiLevelTerrainGenerator;
 import com.faforever.neroxis.generator.terrain.TerrainGenerator;
 
@@ -8,5 +19,19 @@ public class MultiLevelStyleGenerator extends StyleGenerator {
     @Override
     protected WeightedOptionsWithFallback<TerrainGenerator> getTerrainGeneratorOptions() {
         return WeightedOptionsWithFallback.of(new MultiLevelTerrainGenerator());
+    }
+
+    @Override
+    protected WeightedOptionsWithFallback<PropGenerator> getPropGeneratorOptions() {
+        return WeightedOptionsWithFallback.of(new BasicPropGenerator(),
+                                              new WeightedOption<>(new BasicPropGenerator(), 1f),
+                                              new WeightedOption<>(new BoulderFieldPropGenerator(), .1f),
+                                              new WeightedOption<>(new EnemyCivPropGenerator(), .5f),
+                                              new WeightedOption<>(new HighReclaimPropGenerator(), .25f),
+                                              new WeightedOption<>(new LargeBattlePropGenerator(), .5f),
+                                              new WeightedOption<>(new NavyWrecksPropGenerator(), 2f),
+                                              new WeightedOption<>(new NeutralCivPropGenerator(), 1f),
+                                              new WeightedOption<>(new RockFieldPropGenerator(), 1f),
+                                              new WeightedOption<>(new SmallBattlePropGenerator(), 1f));
     }
 }

--- a/generator/src/main/java/com/faforever/neroxis/generator/style/MultiLevelStyleGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/style/MultiLevelStyleGenerator.java
@@ -1,0 +1,12 @@
+package com.faforever.neroxis.generator.style;
+
+import com.faforever.neroxis.generator.WeightedOptionsWithFallback;
+import com.faforever.neroxis.generator.terrain.MultiLevelTerrainGenerator;
+import com.faforever.neroxis.generator.terrain.TerrainGenerator;
+
+public class MultiLevelStyleGenerator extends StyleGenerator {
+    @Override
+    protected WeightedOptionsWithFallback<TerrainGenerator> getTerrainGeneratorOptions() {
+        return WeightedOptionsWithFallback.of(new MultiLevelTerrainGenerator());
+    }
+}

--- a/generator/src/main/java/com/faforever/neroxis/generator/style/RiversAndOceansStyleGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/style/RiversAndOceansStyleGenerator.java
@@ -1,6 +1,17 @@
 package com.faforever.neroxis.generator.style;
 
+import com.faforever.neroxis.generator.WeightedOption;
 import com.faforever.neroxis.generator.WeightedOptionsWithFallback;
+import com.faforever.neroxis.generator.prop.BasicPropGenerator;
+import com.faforever.neroxis.generator.prop.BoulderFieldPropGenerator;
+import com.faforever.neroxis.generator.prop.EnemyCivPropGenerator;
+import com.faforever.neroxis.generator.prop.HighReclaimPropGenerator;
+import com.faforever.neroxis.generator.prop.LargeBattlePropGenerator;
+import com.faforever.neroxis.generator.prop.NavyWrecksPropGenerator;
+import com.faforever.neroxis.generator.prop.NeutralCivPropGenerator;
+import com.faforever.neroxis.generator.prop.PropGenerator;
+import com.faforever.neroxis.generator.prop.RockFieldPropGenerator;
+import com.faforever.neroxis.generator.prop.SmallBattlePropGenerator;
 import com.faforever.neroxis.generator.resource.ResourceGenerator;
 import com.faforever.neroxis.generator.resource.RiversAndOceansMexResourceGenerator;
 import com.faforever.neroxis.generator.terrain.RiversAndOceansTerrainGenerator;
@@ -16,5 +27,19 @@ public class RiversAndOceansStyleGenerator extends StyleGenerator {
     @Override
     protected WeightedOptionsWithFallback<TerrainGenerator> getTerrainGeneratorOptions() {
         return WeightedOptionsWithFallback.of(new RiversAndOceansTerrainGenerator());
+    }
+
+    @Override
+    protected WeightedOptionsWithFallback<PropGenerator> getPropGeneratorOptions() {
+        return WeightedOptionsWithFallback.of(new BasicPropGenerator(),
+                                              new WeightedOption<>(new BasicPropGenerator(), 1f),
+                                              new WeightedOption<>(new BoulderFieldPropGenerator(), .1f),
+                                              new WeightedOption<>(new EnemyCivPropGenerator(), .5f),
+                                              new WeightedOption<>(new HighReclaimPropGenerator(), .25f),
+                                              new WeightedOption<>(new LargeBattlePropGenerator(), .5f),
+                                              new WeightedOption<>(new NavyWrecksPropGenerator(), 2f),
+                                              new WeightedOption<>(new NeutralCivPropGenerator(), 1f),
+                                              new WeightedOption<>(new RockFieldPropGenerator(), 1f),
+                                              new WeightedOption<>(new SmallBattlePropGenerator(), 1f));
     }
 }

--- a/generator/src/main/java/com/faforever/neroxis/generator/style/RiversStyleGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/style/RiversStyleGenerator.java
@@ -1,6 +1,17 @@
 package com.faforever.neroxis.generator.style;
 
+import com.faforever.neroxis.generator.WeightedOption;
 import com.faforever.neroxis.generator.WeightedOptionsWithFallback;
+import com.faforever.neroxis.generator.prop.BasicPropGenerator;
+import com.faforever.neroxis.generator.prop.BoulderFieldPropGenerator;
+import com.faforever.neroxis.generator.prop.EnemyCivPropGenerator;
+import com.faforever.neroxis.generator.prop.HighReclaimPropGenerator;
+import com.faforever.neroxis.generator.prop.LargeBattlePropGenerator;
+import com.faforever.neroxis.generator.prop.NavyWrecksPropGenerator;
+import com.faforever.neroxis.generator.prop.NeutralCivPropGenerator;
+import com.faforever.neroxis.generator.prop.PropGenerator;
+import com.faforever.neroxis.generator.prop.RockFieldPropGenerator;
+import com.faforever.neroxis.generator.prop.SmallBattlePropGenerator;
 import com.faforever.neroxis.generator.terrain.RiversTerrainGenerator;
 import com.faforever.neroxis.generator.terrain.TerrainGenerator;
 
@@ -9,6 +20,20 @@ public class RiversStyleGenerator extends StyleGenerator {
     @Override
     protected WeightedOptionsWithFallback<TerrainGenerator> getTerrainGeneratorOptions() {
         return WeightedOptionsWithFallback.of(new RiversTerrainGenerator());
+    }
+
+    @Override
+    protected WeightedOptionsWithFallback<PropGenerator> getPropGeneratorOptions() {
+        return WeightedOptionsWithFallback.of(new BasicPropGenerator(),
+                                              new WeightedOption<>(new BasicPropGenerator(), 1f),
+                                              new WeightedOption<>(new BoulderFieldPropGenerator(), .1f),
+                                              new WeightedOption<>(new EnemyCivPropGenerator(), .5f),
+                                              new WeightedOption<>(new HighReclaimPropGenerator(), .25f),
+                                              new WeightedOption<>(new LargeBattlePropGenerator(), .5f),
+                                              new WeightedOption<>(new NavyWrecksPropGenerator(), 2f),
+                                              new WeightedOption<>(new NeutralCivPropGenerator(), 1f),
+                                              new WeightedOption<>(new RockFieldPropGenerator(), 1f),
+                                              new WeightedOption<>(new SmallBattlePropGenerator(), 1f));
     }
 }
 

--- a/generator/src/main/java/com/faforever/neroxis/generator/terrain/FloodedMultiLevelTerrainGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/terrain/FloodedMultiLevelTerrainGenerator.java
@@ -1,0 +1,57 @@
+package com.faforever.neroxis.generator.terrain;
+
+import com.faforever.neroxis.generator.GeneratorParameters;
+import com.faforever.neroxis.map.SCMap;
+import com.faforever.neroxis.map.SymmetrySettings;
+import com.faforever.neroxis.mask.BooleanMask;
+import com.faforever.neroxis.util.vector.Vector2;
+import com.faforever.neroxis.util.vector.Vector3;
+
+public class FloodedMultiLevelTerrainGenerator extends MultiLevelTerrainGenerator {
+    @Override
+    public void initialize(SCMap map, long seed, GeneratorParameters generatorParameters,
+                           SymmetrySettings symmetrySettings) {
+        super.initialize(map, seed, generatorParameters, symmetrySettings);
+
+        waterHeight -= plateauHeight - 2f;
+        spawnLandHeight = landHeight + plateauHeight;
+
+        landNoiseMapFirstLevel = 0.40f;
+        landNoiseMapSecondLevel = 0.52f;
+        landNoiseMapThirdLevel = 0.61f;
+    }
+
+    @Override
+    protected void mountainSetup() {
+        mountains.setSize(map.getSize() + 1);
+    }
+
+    @Override
+    protected void landSetup() {
+        super.landSetup();
+        int mapSize = map.getSize();
+
+        if (mapSize < 512) {
+            BooleanMask connectionsMask = connections.copy().dilute(1, 18).setSize(land.getSize());
+            land.add(connectionsMask);
+            secondLevelLand.add(connectionsMask);
+        }
+
+        String[] SPAWN_MASK_BRUSHES = {
+                "mountain4.png",
+                "mountain6.png",
+                "mountain7.png",
+                "mountain8.png",
+                "mountain9.png",
+        };
+        map.getSpawns().forEach(spawn -> {
+            if (spawn.getTeamID() == 0) {
+                Vector3 location = spawn.getPosition();
+                String brush = SPAWN_MASK_BRUSHES[StrictMath.abs(random.nextInt()) % SPAWN_MASK_BRUSHES.length];
+                System.out.println("Adding " + brush + " to " + location.toString());
+                land.addBrush(new Vector2(location.x(), location.z()), brush, 15f, 256f, 200);
+                secondLevelLand.addBrush(new Vector2(location.x(), location.z()), brush, 15f, 256f, 200);
+            }
+        });
+    }
+}

--- a/generator/src/main/java/com/faforever/neroxis/generator/terrain/FloodedMultiLevelTerrainGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/terrain/FloodedMultiLevelTerrainGenerator.java
@@ -14,7 +14,6 @@ public class FloodedMultiLevelTerrainGenerator extends MultiLevelTerrainGenerato
         super.initialize(map, seed, generatorParameters, symmetrySettings);
 
         waterHeight -= plateauHeight - 2f;
-        spawnLandHeight = landHeight + plateauHeight;
 
         landNoiseMapFirstLevel = 0.40f;
         landNoiseMapSecondLevel = 0.52f;
@@ -29,26 +28,18 @@ public class FloodedMultiLevelTerrainGenerator extends MultiLevelTerrainGenerato
     @Override
     protected void landSetup() {
         super.landSetup();
-        int mapSize = map.getSize();
 
+        int mapSize = map.getSize();
         if (mapSize < 512) {
             BooleanMask connectionsMask = connections.copy().dilute(1, 18).setSize(land.getSize());
             land.add(connectionsMask);
             secondLevelLand.add(connectionsMask);
         }
 
-        String[] SPAWN_MASK_BRUSHES = {
-                "mountain4.png",
-                "mountain6.png",
-                "mountain7.png",
-                "mountain8.png",
-                "mountain9.png",
-        };
         map.getSpawns().forEach(spawn -> {
             if (spawn.getTeamID() == 0) {
                 Vector3 location = spawn.getPosition();
                 String brush = SPAWN_MASK_BRUSHES[StrictMath.abs(random.nextInt()) % SPAWN_MASK_BRUSHES.length];
-                System.out.println("Adding " + brush + " to " + location.toString());
                 land.addBrush(new Vector2(location.x(), location.z()), brush, 15f, 256f, 200);
                 secondLevelLand.addBrush(new Vector2(location.x(), location.z()), brush, 15f, 256f, 200);
             }

--- a/generator/src/main/java/com/faforever/neroxis/generator/terrain/MultiLevelTerrainGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/terrain/MultiLevelTerrainGenerator.java
@@ -6,6 +6,7 @@ import com.faforever.neroxis.map.SCMap;
 import com.faforever.neroxis.map.SymmetrySettings;
 import com.faforever.neroxis.mask.BooleanMask;
 import com.faforever.neroxis.mask.FloatMask;
+import com.faforever.neroxis.mask.MapMaskMethods;
 import com.faforever.neroxis.util.vector.Vector3;
 
 public class MultiLevelTerrainGenerator extends BasicTerrainGenerator {
@@ -188,8 +189,8 @@ public class MultiLevelTerrainGenerator extends BasicTerrainGenerator {
                      .blur(1, spawnPlateauMask.copy().inflate(4))
                      .add(heightmapOcean);
 
-        heightmapLand.flattenSpawnPointsWithRadius(map.getSpawns(), "mountain4.png",spawnSize)
-                     .blur(5, spawnLandMask);
+        MapMaskMethods.flattenSpawnPointsWithRadius(map, heightmapLand, "mountain4.png", spawnSize);
+        heightmapLand.blur(5, spawnLandMask);
 
         heightmap.add(heightmapLand)
                  .add(waterHeight);

--- a/generator/src/main/java/com/faforever/neroxis/generator/terrain/MultiLevelTerrainGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/terrain/MultiLevelTerrainGenerator.java
@@ -15,11 +15,18 @@ public class MultiLevelTerrainGenerator extends BasicTerrainGenerator {
 
     protected FloatMask treeGroupDensityMap;
 
-    protected float spawnLandHeight;
 
     protected float landNoiseMapFirstLevel;
     protected float landNoiseMapSecondLevel;
     protected float landNoiseMapThirdLevel;
+
+    String[] SPAWN_MASK_BRUSHES = {
+            "mountain4.png",
+            "mountain6.png",
+            "mountain7.png",
+            "mountain8.png",
+            "mountain9.png",
+    };
 
     @Override
     public void initialize(SCMap map, long seed, GeneratorParameters generatorParameters,
@@ -35,7 +42,6 @@ public class MultiLevelTerrainGenerator extends BasicTerrainGenerator {
         landNoiseMapSecondLevel = 0.52f;
         landNoiseMapThirdLevel = 0.61f;
 
-        spawnLandHeight = landHeight;
         spawnSize = 48;
 
         plateauHeight = 6f;
@@ -97,8 +103,6 @@ public class MultiLevelTerrainGenerator extends BasicTerrainGenerator {
 
         plateaus.subtract(spawnLandMask).add(spawnPlateauMask);
         land.add(spawnLandMask).add(spawnPlateauMask);
-        // Don't remove the spawnMask from the second level land. The spawn's are allowed on the 2nd level.
-        // secondLevelLand.subtract(spawnLandMask);
         thirdLevelLand.subtract(spawnLandMask);
 
         mountains.subtract(spawnLandMask.copy().inflate(mountainBrushSize / 4f));
@@ -109,7 +113,6 @@ public class MultiLevelTerrainGenerator extends BasicTerrainGenerator {
 
     @Override
     protected void plateausSetup() {
-        // Disable plateaus for this terrain generator
         int mapSize = map.getSize();
         plateaus.setSize(mapSize + 1);
     }
@@ -179,20 +182,17 @@ public class MultiLevelTerrainGenerator extends BasicTerrainGenerator {
                      .blur(1, thirdLevelLand.copy().inflate(6));
 
 
-        heightmapLand
-                     .add(heightmapPlateaus)
+        heightmapLand.add(heightmapPlateaus)
                      .setToValue(spawnPlateauMask, plateauHeight + landHeight)
                      .blur(1, spawnLandMask.copy().inflate(4))
                      .blur(1, spawnPlateauMask.copy().inflate(4))
                      .add(heightmapOcean);
 
-        // Level out the terrain at the spawn points
-        heightmapLand.flattenSpawnPointsWithRadius(map.getSpawns(), spawnLandMask, spawnSize);
-        heightmapLand.blur(3, spawnLandMask);
+        heightmapLand.flattenSpawnPointsWithRadius(map.getSpawns(), "mountain4.png",spawnSize)
+                     .blur(5, spawnLandMask);
 
-        heightmap
-                .add(heightmapLand)
-                .add(waterHeight);
+        heightmap.add(heightmapLand)
+                 .add(waterHeight);
 
         if (heightMapNoise.getSymmetrySettings().spawnSymmetry().isPerfectSymmetry()) {
             heightMapNoise.addWhiteNoise(plateauHeight / 3).resample(mapSize / 64);

--- a/generator/src/main/java/com/faforever/neroxis/generator/terrain/MultiLevelTerrainGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/terrain/MultiLevelTerrainGenerator.java
@@ -42,7 +42,7 @@ public class MultiLevelTerrainGenerator extends BasicTerrainGenerator {
         landNoiseMapSecondLevel = 0.52f;
         landNoiseMapThirdLevel = 0.61f;
 
-        spawnSize = 48;
+        spawnSize = 64;
 
         plateauHeight = 6f;
         plateauBrushIntensity = 16f;
@@ -133,7 +133,7 @@ public class MultiLevelTerrainGenerator extends BasicTerrainGenerator {
 
     @Override
     protected void blurRamps() {
-        BooleanMask inflatedRamps = ramps.copy();
+        BooleanMask inflatedRamps = ramps.copy().subtract(spawnLandMask);
         heightmap.blur(48, inflatedRamps)
                  .blur(32, inflatedRamps.inflate(2))
                  .blur(4, inflatedRamps.copy().outline().inflate(4))

--- a/generator/src/main/java/com/faforever/neroxis/generator/terrain/MultiLevelTerrainGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/terrain/MultiLevelTerrainGenerator.java
@@ -1,0 +1,221 @@
+package com.faforever.neroxis.generator.terrain;
+
+import com.faforever.neroxis.brushes.Brushes;
+import com.faforever.neroxis.generator.GeneratorParameters;
+import com.faforever.neroxis.map.SCMap;
+import com.faforever.neroxis.map.SymmetrySettings;
+import com.faforever.neroxis.mask.BooleanMask;
+import com.faforever.neroxis.mask.FloatMask;
+import com.faforever.neroxis.util.vector.Vector3;
+
+public class MultiLevelTerrainGenerator extends BasicTerrainGenerator {
+
+    protected BooleanMask secondLevelLand;
+    protected BooleanMask thirdLevelLand;
+
+    protected FloatMask treeGroupDensityMap;
+
+    protected float spawnLandHeight;
+
+    protected float landNoiseMapFirstLevel;
+    protected float landNoiseMapSecondLevel;
+    protected float landNoiseMapThirdLevel;
+
+    @Override
+    public void initialize(SCMap map, long seed, GeneratorParameters generatorParameters,
+                           SymmetrySettings symmetrySettings) {
+        super.initialize(map, seed, generatorParameters, symmetrySettings);
+
+        secondLevelLand = new BooleanMask(1, random.nextLong(), symmetrySettings, "secondLevelLand", true);
+        thirdLevelLand = new BooleanMask(1, random.nextLong(), symmetrySettings, "secondLevelLand", true);
+
+        treeGroupDensityMap = new FloatMask(1, random.nextLong(), symmetrySettings, "treeGroupDensityMap", true);
+
+        landNoiseMapFirstLevel = 0.385f;
+        landNoiseMapSecondLevel = 0.52f;
+        landNoiseMapThirdLevel = 0.61f;
+
+        spawnLandHeight = landHeight;
+        spawnSize = 48;
+
+        plateauHeight = 6f;
+        plateauBrushIntensity = 16f;
+
+        mountainDensity = random.nextFloat() / 3;
+    }
+
+    @Override
+    protected void landSetup() {
+        int mapSize = map.getSize();
+
+        int MAX_OCTAVES = 7;
+        int numOctaves = 0;
+        int smallestDetail = 5;
+
+        while (numOctaves < MAX_OCTAVES && smallestDetail << numOctaves <= mapSize) {
+            numOctaves++;
+        }
+
+        FloatMask landNoiseMap = new FloatMask(mapSize, getRandom().nextLong(), land.getSymmetrySettings(), "landNoiseMap", true);
+        for (int octave = 0; octave < numOctaves; octave++) {
+            FloatMask octaveNoise = new FloatMask(mapSize, getRandom().nextLong(), land.getSymmetrySettings(), "landNoiseOctave" + octave, true);
+            octaveNoise.addPerlinNoise(smallestDetail << octave,1f / numOctaves);
+            landNoiseMap.add(octaveNoise);
+        }
+        landNoiseMap.blur(8);
+
+        float firstLevel = landNoiseMapFirstLevel;
+        float secondLevel = random.nextFloat(landNoiseMapSecondLevel, landNoiseMapSecondLevel + 0.02f);
+        float thirdLevel = random.nextFloat(landNoiseMapThirdLevel, landNoiseMapThirdLevel + 0.03f);
+
+        land = landNoiseMap
+                .copyAsBooleanMask(firstLevel)
+                .erode(0.3f, 10)
+                .setSize(mapSize+1);
+        secondLevelLand = landNoiseMap
+                .copyAsBooleanMask(secondLevel)
+                .erode(0.3f, 10)
+                .setSize(mapSize+1);
+        thirdLevelLand = landNoiseMap
+                .copyAsBooleanMask(thirdLevel)
+                .erode(0.3f, 10)
+                .setSize(mapSize+1);
+    }
+
+    @Override
+    protected void spawnTerrainSetup() {
+        int mapSize = map.getSize();
+        spawnPlateauMask.setSize(mapSize / 4);
+        spawnPlateauMask.erode(.5f, 4).dilute(.5f, 8);
+        spawnPlateauMask.erode(.5f).setSize(mapSize + 1);
+        spawnPlateauMask.blur(4);
+
+        spawnLandMask.setSize(mapSize / 4);
+        spawnLandMask.erode(.25f, mapSize / 128).dilute(.5f, 4);
+        spawnLandMask.erode(.5f).setSize(mapSize + 1);
+        spawnLandMask.blur(4);
+
+        plateaus.subtract(spawnLandMask).add(spawnPlateauMask);
+        land.add(spawnLandMask).add(spawnPlateauMask);
+        // Don't remove the spawnMask from the second level land. The spawn's are allowed on the 2nd level.
+        // secondLevelLand.subtract(spawnLandMask);
+        thirdLevelLand.subtract(spawnLandMask);
+
+        mountains.subtract(spawnLandMask.copy().inflate(mountainBrushSize / 4f));
+
+        plateaus.multiply(land).subtract(spawnLandMask).add(spawnPlateauMask);
+        land.add(plateaus).add(spawnLandMask).add(spawnPlateauMask);
+    }
+
+    @Override
+    protected void plateausSetup() {
+        // Disable plateaus for this terrain generator
+        int mapSize = map.getSize();
+        plateaus.setSize(mapSize + 1);
+    }
+
+    @Override
+    protected void initRamps() {
+        ramps.setSize(map.getSize() + 1);
+
+        ramps = secondLevelLand.copy();
+        ramps.outline();
+
+        FloatMask rampExclusion = new FloatMask(ramps.getSize(), random.nextLong(), this.symmetrySettings, "rampExclusion", true);
+        rampExclusion.addPerlinNoise(StrictMath.min(128, rampExclusion.getSize()), 1);
+        BooleanMask rampExclusionMask = rampExclusion.copyAsBooleanMask(0.4f, 0.6f);
+
+        ramps.subtract(rampExclusionMask.invert());
+    }
+
+    @Override
+    protected void blurRamps() {
+        BooleanMask inflatedRamps = ramps.copy();
+        heightmap.blur(48, inflatedRamps)
+                 .blur(32, inflatedRamps.inflate(2))
+                 .blur(4, inflatedRamps.copy().outline().inflate(4))
+                 .blur(6, inflatedRamps.copy().outline().inflate(6))
+                 .clampMin(0f)
+                 .clampMax(255f);
+    }
+
+    @Override
+    protected void setupHeightmapPipeline() {
+        int mapSize = map.getSize();
+        int numBrushes = Brushes.GENERATOR_BRUSHES.size();
+
+        String brush = Brushes.GENERATOR_BRUSHES.get(random.nextInt(numBrushes));
+
+        setupMountainHeightmapPipeline();
+        setupPlateauHeightmapPipeline();
+        setupSmallFeatureHeightmapPipeline();
+        initRamps();
+
+        BooleanMask water = land.copy().invert();
+        BooleanMask deepWater = water.copy().deflate(32);
+
+        heightmap.setSize(mapSize + 1);
+        heightmapLand.setSize(mapSize + 1);
+        heightmapOcean.setSize(mapSize + 1);
+        heightMapNoise.setSize(mapSize / 128);
+
+        heightmapOcean.addDistance(land, -.45f)
+                      .clampMin(oceanFloor)
+                      .useBrushWithinAreaWithDensity(water.deflate(8).subtract(deepWater), brush, shallowWaterBrushSize,
+                                                     shallowWaterBrushDensity, shallowWaterBrushIntensity, false)
+                      .useBrushWithinAreaWithDensity(deepWater, brush, deepWaterBrushSize, deepWaterBrushDensity,
+                                                     deepWaterBrushIntensity, false)
+                      .clampMax(0f)
+                      .blur(4, deepWater)
+                      .blur(1);
+
+        heightmapLand.add(heightmapHills)
+                     .add(heightmapValleys)
+                     .add(heightmapMountains)
+                     .add(landHeight)
+                     .add(secondLevelLand, plateauHeight)
+                     .blur(1, secondLevelLand.copy().inflate(6))
+                     .add(thirdLevelLand, plateauHeight)
+                     .blur(1, thirdLevelLand.copy().inflate(6));
+
+
+        heightmapLand
+                     .add(heightmapPlateaus)
+                     .setToValue(spawnPlateauMask, plateauHeight + landHeight)
+                     .blur(1, spawnLandMask.copy().inflate(4))
+                     .blur(1, spawnPlateauMask.copy().inflate(4))
+                     .add(heightmapOcean);
+
+        // Level out the terrain at the spawn points
+        heightmapLand.flattenSpawnPointsWithRadius(map.getSpawns(), spawnLandMask, spawnSize);
+        heightmapLand.blur(3, spawnLandMask);
+
+        heightmap
+                .add(heightmapLand)
+                .add(waterHeight);
+
+        if (heightMapNoise.getSymmetrySettings().spawnSymmetry().isPerfectSymmetry()) {
+            heightMapNoise.addWhiteNoise(plateauHeight / 3).resample(mapSize / 64);
+            heightMapNoise.addWhiteNoise(plateauHeight / 3).resample(mapSize + 1);
+            heightMapNoise.addWhiteNoise(1)
+                          .subtractAvg()
+                          .clampMin(0f)
+                          .setToValue(land.copy().invert().inflate(16), 0f)
+                          .blur(mapSize / 16, spawnLandMask.copy().inflate(8))
+                          .blur(mapSize / 16, spawnPlateauMask.copy().inflate(8))
+                          .blur(mapSize / 16);
+            heightmap.add(heightMapNoise);
+        }
+
+        blurRamps();
+    }
+
+    @Override
+    protected void spawnMaskSetup() {
+        map.getSpawns().forEach(spawn -> {
+            Vector3 location = spawn.getPosition();
+            spawnLandMask.fillCircle(location, spawnSize, true);
+        });
+    }
+
+}

--- a/shared/src/main/java/com/faforever/neroxis/mask/FloatMask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/FloatMask.java
@@ -424,24 +424,34 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
         }, other);
     }
 
-    public FloatMask flattenSpawnPointsWithRadius(List<Spawn> spawns, BooleanMask spawnMask, int radius) {
+    /**
+     * Take the height value for each spawn point provided, and set the surrounding terrain to the same height, within
+     * a brush mask.
+     * @param spawns    The list of spawns
+     * @param brush     The brush to use for each spawn, this brush masks off the surrounding terrain to be leveled
+     * @param radius    The radius of the spawn mask to use for flattening
+     */
+    public FloatMask flattenSpawnPointsWithRadius(List<Spawn> spawns, String brush, int radius) {
         return enqueue(dependencies -> {
-            BooleanMask sourceSpawnMask = (BooleanMask) dependencies.getFirst();
-            spawns.forEach(spawn -> {
+            spawns.stream()
+                  .forEach(spawn -> {
                       Vector3 location = spawn.getPosition();
                       float height = get(location);
                       int spawnPointX = (int)location.x();
                       int spawnPointY = (int)location.z();
 
+                      BooleanMask spawnBrushMask = new BooleanMask(getSize(), null, getSymmetrySettings()).startVisualDebugger();
+                      spawnBrushMask.addBrush(new Vector2(location), brush, 15f, 256f, radius * 2);
+
                       for (int x = spawnPointX - radius; x < spawnPointX + radius; x++) {
                           for (int y = spawnPointY - radius; y < spawnPointY + radius; y++) {
-                              if (inBounds(x, y) && sourceSpawnMask.get(x, y)) {
+                              if (inBounds(x, y) && spawnBrushMask.get(x, y)) {
                                   set(x, y, height);
                               }
                           }
                       }
                   });
-        }, spawnMask);
+        });
     }
 
     public BooleanMask copyAsShadowMask(Vector3 lightDirection) {

--- a/shared/src/main/java/com/faforever/neroxis/mask/FloatMask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/FloatMask.java
@@ -434,6 +434,7 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
     public FloatMask flattenSpawnPointsWithRadius(List<Spawn> spawns, String brush, int radius) {
         return enqueue(dependencies -> {
             spawns.stream()
+                  .filter(spawn -> spawn.getTeamID() == 0)
                   .forEach(spawn -> {
                       Vector3 location = spawn.getPosition();
                       float height = get(location);
@@ -443,13 +444,14 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
                       BooleanMask spawnBrushMask = new BooleanMask(getSize(), null, getSymmetrySettings()).startVisualDebugger();
                       spawnBrushMask.addBrush(new Vector2(location), brush, 15f, 256f, radius * 2);
 
-                      for (int x = spawnPointX - radius; x < spawnPointX + radius; x++) {
-                          for (int y = spawnPointY - radius; y < spawnPointY + radius; y++) {
-                              if (inBounds(x, y) && spawnBrushMask.get(x, y)) {
-                                  set(x, y, height);
-                              }
+                      setPrimitiveWithSymmetry(SymmetryType.SPAWN, (x, y) -> {
+                          if (spawnBrushMask.get(x, y)) {
+                              return height;
+                          } else {
+                              return getPrimitive(x, y);
                           }
-                      }
+                      });
+
                   });
         });
     }

--- a/shared/src/main/java/com/faforever/neroxis/mask/FloatMask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/FloatMask.java
@@ -1,6 +1,5 @@
 package com.faforever.neroxis.mask;
 
-import com.faforever.neroxis.map.Spawn;
 import com.faforever.neroxis.map.Symmetry;
 import com.faforever.neroxis.map.SymmetrySettings;
 import com.faforever.neroxis.map.SymmetryType;
@@ -149,8 +148,7 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
         int size = getSize();
         int gradientSize = size / resolution;
         if (gradientSize <= 0) {
-            System.err.println("FloatMask:addPerlinNoise(): resolution "+resolution+" can't be greater than mask size " + size);
-            System.exit(2);
+            throw new RuntimeException("FloatMask:addPerlinNoise(): resolution " + resolution + " can't be greater than mask size " + size);
         }
         float gradientScale = (float) size / gradientSize;
         Vector2Mask gradientVectors = new Vector2Mask(gradientSize +
@@ -422,38 +420,6 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
                 addWithOffset(brush, location, true, wrapEdges);
             }
         }, other);
-    }
-
-    /**
-     * Take the height value for each spawn point provided, and set the surrounding terrain to the same height, within
-     * a brush mask.
-     * @param spawns    The list of spawns
-     * @param brush     The brush to use for each spawn, this brush masks off the surrounding terrain to be leveled
-     * @param radius    The radius of the spawn mask to use for flattening
-     */
-    public FloatMask flattenSpawnPointsWithRadius(List<Spawn> spawns, String brush, int radius) {
-        return enqueue(dependencies -> {
-            spawns.stream()
-                  .filter(spawn -> spawn.getTeamID() == 0)
-                  .forEach(spawn -> {
-                      Vector3 location = spawn.getPosition();
-                      float height = get(location);
-                      int spawnPointX = (int)location.x();
-                      int spawnPointY = (int)location.z();
-
-                      BooleanMask spawnBrushMask = new BooleanMask(getSize(), null, getSymmetrySettings());
-                      spawnBrushMask.addBrush(new Vector2(location), brush, 15f, 256f, radius * 2);
-
-                      setPrimitiveWithSymmetry(SymmetryType.SPAWN, (x, y) -> {
-                          if (spawnBrushMask.get(x, y)) {
-                              return height;
-                          } else {
-                              return getPrimitive(x, y);
-                          }
-                      });
-
-                  });
-        });
     }
 
     public BooleanMask copyAsShadowMask(Vector3 lightDirection) {

--- a/shared/src/main/java/com/faforever/neroxis/mask/FloatMask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/FloatMask.java
@@ -441,7 +441,7 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
                       int spawnPointX = (int)location.x();
                       int spawnPointY = (int)location.z();
 
-                      BooleanMask spawnBrushMask = new BooleanMask(getSize(), null, getSymmetrySettings()).startVisualDebugger();
+                      BooleanMask spawnBrushMask = new BooleanMask(getSize(), null, getSymmetrySettings());
                       spawnBrushMask.addBrush(new Vector2(location), brush, 15f, 256f, radius * 2);
 
                       setPrimitiveWithSymmetry(SymmetryType.SPAWN, (x, y) -> {

--- a/shared/src/main/java/com/faforever/neroxis/mask/FloatMask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/FloatMask.java
@@ -148,7 +148,7 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
         int size = getSize();
         int gradientSize = size / resolution;
         if (gradientSize <= 0) {
-            throw new RuntimeException("FloatMask:addPerlinNoise(): resolution " + resolution + " can't be greater than mask size " + size);
+            System.err.println("FloatMask:addPerlinNoise(): resolution " + resolution + " can't be greater than mask size " + size);
         }
         float gradientScale = (float) size / gradientSize;
         Vector2Mask gradientVectors = new Vector2Mask(gradientSize +

--- a/shared/src/main/java/com/faforever/neroxis/mask/FloatMask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/FloatMask.java
@@ -1,5 +1,6 @@
 package com.faforever.neroxis.mask;
 
+import com.faforever.neroxis.map.Spawn;
 import com.faforever.neroxis.map.Symmetry;
 import com.faforever.neroxis.map.SymmetrySettings;
 import com.faforever.neroxis.map.SymmetryType;
@@ -147,6 +148,10 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
     public FloatMask addPerlinNoise(int resolution, float scale) {
         int size = getSize();
         int gradientSize = size / resolution;
+        if (gradientSize <= 0) {
+            System.err.println("FloatMask:addPerlinNoise(): resolution "+resolution+" can't be greater than mask size " + size);
+            System.exit(2);
+        }
         float gradientScale = (float) size / gradientSize;
         Vector2Mask gradientVectors = new Vector2Mask(gradientSize +
                                                       1, random.nextLong(), new SymmetrySettings(Symmetry.NONE),
@@ -417,6 +422,26 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
                 addWithOffset(brush, location, true, wrapEdges);
             }
         }, other);
+    }
+
+    public FloatMask flattenSpawnPointsWithRadius(List<Spawn> spawns, BooleanMask spawnMask, int radius) {
+        return enqueue(dependencies -> {
+            BooleanMask sourceSpawnMask = (BooleanMask) dependencies.getFirst();
+            spawns.forEach(spawn -> {
+                      Vector3 location = spawn.getPosition();
+                      float height = get(location);
+                      int spawnPointX = (int)location.x();
+                      int spawnPointY = (int)location.z();
+
+                      for (int x = spawnPointX - radius; x < spawnPointX + radius; x++) {
+                          for (int y = spawnPointY - radius; y < spawnPointY + radius; y++) {
+                              if (inBounds(x, y) && sourceSpawnMask.get(x, y)) {
+                                  set(x, y, height);
+                              }
+                          }
+                      }
+                  });
+        }, spawnMask);
     }
 
     public BooleanMask copyAsShadowMask(Vector3 lightDirection) {

--- a/shared/src/main/java/com/faforever/neroxis/mask/MapMaskMethods.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/MapMaskMethods.java
@@ -172,4 +172,27 @@ public class MapMaskMethods {
             }
         });
     }
+
+    public static FloatMask flattenSpawnPointsWithRadius(SCMap map, FloatMask exec, String brush, int spawnSize) {
+        return exec.enqueue(() -> {
+            map.getSpawns()
+               .stream()
+               .filter(spawn -> spawn.getTeamID() == 0)
+               .forEach(spawn -> {
+                   Vector3 location = spawn.getPosition();
+                   float height = exec.get(location);
+
+                   BooleanMask spawnBrushMask = new BooleanMask(exec.getSize(), null, exec.getSymmetrySettings());
+                   spawnBrushMask.addBrush(new Vector2(location), brush, 15f, 256f, spawnSize * 2);
+
+                   exec.setPrimitiveWithSymmetry(SymmetryType.SPAWN, (x, y) -> {
+                       if (spawnBrushMask.get(x, y)) {
+                           return height;
+                       } else {
+                           return exec.getPrimitive(x, y);
+                       }
+                   });
+               });
+        });
+    }
 }


### PR DESCRIPTION
Adds a new terrain generator, using multiple perlin noise layers added together, where the noise scale increases for each layer.

The theory:
Uses this concept: https://devforum.roblox.com/t/creating-procedural-mountains-a-fractal-noise-tutorial/1494362
And also domstrated here: https://github.com/PierfrancescoSoffritti/HeightMapGenerator/blob/master/README.md

So I made a terrain generator out of this stuff,
It uses up to 7 layers of Perlin noise...   (5K maps use 5 layers..)
![image](https://github.com/user-attachments/assets/6bcb5a62-4745-4c67-a43b-0fb1b0bdd36a)

And this is some previews for some maps that it generates:
5K multi_level
![image](https://github.com/user-attachments/assets/07d7cc7d-2e58-4065-8bee-a879912aebb9)
10K multi_level
![image](https://github.com/user-attachments/assets/c4dc2d23-9bbd-4a63-a70e-49667945f806)
20K multi_level
![image](https://github.com/user-attachments/assets/48e10c20-7fe1-4b4d-9da3-e6806b72b7df)

5K flooded_multi_level
![image](https://github.com/user-attachments/assets/95d2dcfb-9336-4743-86e2-4de4fba4bad9)
10K flooded_multi_level
![image](https://github.com/user-attachments/assets/e683a572-ebdb-44d8-aa17-b11782f10430)
20K flooded_multi_level
![image](https://github.com/user-attachments/assets/2e2a0614-d1e9-4012-93de-baf216e82a6e)

20K flooded:
![image](https://github.com/user-attachments/assets/c3ab0d6f-1fb8-44f4-9d7e-76454a7930b8)
