### PR TITLE
Changes to rivers terrain gen

### DIFF
--- a/generator/src/main/java/com/faforever/neroxis/generator/MapStyle.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/MapStyle.java
@@ -37,12 +37,12 @@ public enum MapStyle {
     LOW_MEX(LowMexStyleGenerator.class, LowMexStyleGenerator::new, .5f),
     MOUNTAIN_RANGE(MountainRangeStyleGenerator.class, MountainRangeStyleGenerator::new, 1),
     MULTILEVEL(MultiLevelStyleGenerator.class, MultiLevelStyleGenerator::new, 1),
-    FLOODED_MULTILEVEL(FloodedMultiLevelStyleGenerator.class, FloodedMultiLevelStyleGenerator::new, 1),
+    FLOODED_MULTILEVEL(FloodedMultiLevelStyleGenerator.class, FloodedMultiLevelStyleGenerator::new, 0.75f),
     ONE_ISLAND(OneIslandStyleGenerator.class, OneIslandStyleGenerator::new, 1),
     SMALL_ISLANDS(SmallIslandsStyleGenerator.class, SmallIslandsStyleGenerator::new, 4),
     VALLEY(ValleyStyleGenerator.class, ValleyStyleGenerator::new, 1),
-    RIVERS(RiversStyleGenerator.class, RiversStyleGenerator::new, 1),
-    RIVERS_AND_OCEANS(RiversAndOceansStyleGenerator.class, RiversAndOceansStyleGenerator::new, 1);
+    RIVERS(RiversStyleGenerator.class, RiversStyleGenerator::new, 0.1f),
+    RIVERS_AND_OCEANS(RiversAndOceansStyleGenerator.class, RiversAndOceansStyleGenerator::new, 0.75f);
 
     private final Class<? extends StyleGenerator> generatorClass;
     private final Supplier<StyleGenerator> generatorSupplier;

--- a/generator/src/main/java/com/faforever/neroxis/generator/MapStyle.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/MapStyle.java
@@ -27,7 +27,7 @@ import java.util.function.Supplier;
 @AllArgsConstructor
 public enum MapStyle {
     BASIC(BasicStyleGenerator.class, BasicStyleGenerator::new, 1),
-    BIG_ISLANDS(BigIslandsStyleGenerator.class, BigIslandsStyleGenerator::new, 4),
+    BIG_ISLANDS(BigIslandsStyleGenerator.class, BigIslandsStyleGenerator::new, 1),
     CENTER_LAKE(CenterLakeStyleGenerator.class, CenterLakeStyleGenerator::new, 1),
     DROP_PLATEAU(DropPlateauStyleGenerator.class, DropPlateauStyleGenerator::new, .5f),
     FLOODED(FloodedStyleGenerator.class, FloodedStyleGenerator::new, .01f),
@@ -36,12 +36,12 @@ public enum MapStyle {
     LITTLE_MOUNTAIN(LittleMountainStyleGenerator.class, LittleMountainStyleGenerator::new, 1),
     LOW_MEX(LowMexStyleGenerator.class, LowMexStyleGenerator::new, .5f),
     MOUNTAIN_RANGE(MountainRangeStyleGenerator.class, MountainRangeStyleGenerator::new, 1),
-    MULTILEVEL(MultiLevelStyleGenerator.class, MultiLevelStyleGenerator::new, 1),
+    MULTILEVEL(MultiLevelStyleGenerator.class, MultiLevelStyleGenerator::new, 1f),
     FLOODED_MULTILEVEL(FloodedMultiLevelStyleGenerator.class, FloodedMultiLevelStyleGenerator::new, 0.75f),
     ONE_ISLAND(OneIslandStyleGenerator.class, OneIslandStyleGenerator::new, 1),
-    SMALL_ISLANDS(SmallIslandsStyleGenerator.class, SmallIslandsStyleGenerator::new, 4),
+    SMALL_ISLANDS(SmallIslandsStyleGenerator.class, SmallIslandsStyleGenerator::new, 1),
     VALLEY(ValleyStyleGenerator.class, ValleyStyleGenerator::new, 1),
-    RIVERS(RiversStyleGenerator.class, RiversStyleGenerator::new, 0.1f),
+    RIVERS(RiversStyleGenerator.class, RiversStyleGenerator::new, 0.25f),
     RIVERS_AND_OCEANS(RiversAndOceansStyleGenerator.class, RiversAndOceansStyleGenerator::new, 0.75f);
 
     private final Class<? extends StyleGenerator> generatorClass;

--- a/generator/src/main/java/com/faforever/neroxis/generator/terrain/RiversTerrainGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/terrain/RiversTerrainGenerator.java
@@ -28,7 +28,9 @@ public class RiversTerrainGenerator extends BasicTerrainGenerator {
 
         mountainBrushSize = 24;
         mountainBrushDensity = 8f;
-        mountainBrushIntensity = 0.4f;
+        mountainBrushIntensity = 0.8f;
+
+        spawnSize = 48;
     }
 
     @Override
@@ -42,17 +44,10 @@ public class RiversTerrainGenerator extends BasicTerrainGenerator {
         rivers.addPerlinNoise(StrictMath.min(96 + riversScale, mapSize), 1);
         riverMask = rivers.copyAsBooleanMask(0.5f, 0.65f);
 
-        FloatMask riverExclusion = new FloatMask(mapSize, getRandom().nextLong(), land.getSymmetrySettings(), "riversExclusion", true);
-        riverExclusion.addPerlinNoise(StrictMath.min(256, mapSize), 1);
-        float exclusionThickness = 0.06f * ((float)mapSize / 256f);
-        riverExclusionMask = riverExclusion.copyAsBooleanMask(0.5f, 0.5f + exclusionThickness);
-        riverMask.subtract(riverExclusionMask);
-        riverExclusionMask.setSize(mapSize+1);
-
         riverMask.invert();
         riverMask.blur(10);
 
-        riverMask.add(connections.copy().dilute(1, 10).setSize(riverMask.getSize()));
+        riverMask.add(connections.copy().dilute(1, 20).setSize(riverMask.getSize()));
 
         riverMask.erode(0.3f, 10);
 
@@ -219,7 +214,7 @@ public class RiversTerrainGenerator extends BasicTerrainGenerator {
     protected void spawnMaskSetup() {
         map.getSpawns().forEach(spawn -> {
             Vector3 location = spawn.getPosition();
-            spawnLandMask.fillCircle(location, 10, true);
+            spawnLandMask.fillCircle(location, spawnSize, true);
         });
     }
 

--- a/generator/src/main/java/com/faforever/neroxis/generator/terrain/RiversTerrainGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/terrain/RiversTerrainGenerator.java
@@ -179,8 +179,8 @@ public class RiversTerrainGenerator extends BasicTerrainGenerator {
                                   .inflate(2);
 
         FloatMask riverMountainExclusion = new FloatMask(mapSize, random.nextLong(), this.symmetrySettings, "riverMountainExclusion", true);
-        riverMountainExclusion.addPerlinNoise(128, 1);
-        BooleanMask riverMountainExclusionMask = riverMountainExclusion.copyAsBooleanMask(0.3f, 0.8f);
+        riverMountainExclusion.addPerlinNoise(64, 1);
+        BooleanMask riverMountainExclusionMask = riverMountainExclusion.copyAsBooleanMask(0.3f, 0.75f);
 
         riverMountains.subtract(riverMountainExclusionMask);
         riverMountains.setSize(mountains.getSize());


### PR DESCRIPTION
Ok so new day, new fixes...
This one comes from criticism of the rivers terrain generator, (the origin of all the shinanigans)
So ultimately the Rivers can produce some bad maps... (not always, but sometimes)
And there some issues as discussed in https://github.com/FAForever/Neroxis-Map-Generator/issues/440

So I've reduced it's prevalance on ladder...

And we've tried to fix the main problem.
Anyway, as always, I gotta spam some pitcures....
This is the next 4 random maps I generated with the changes:
![image](https://github.com/user-attachments/assets/38697708-2b0a-48c5-9402-8692719edc56)
Almost like Twin rivers this one: (no not really)
![image](https://github.com/user-attachments/assets/2a630a66-3aab-4680-9851-8e700e59c518)

![image](https://github.com/user-attachments/assets/f5949422-24d0-4bb3-a328-3312af0e7bc7)
![image](https://github.com/user-attachments/assets/7669340d-5b1b-419e-ae1a-ad9bf819a45b)

So I hope this addresses the issues.. I should definitely pr these fixes.

Maybe I can provide some bfore and after screen shots if needed.
