### PR TITLE
Improve default values for PBR texture generation

### DIFF
--- a/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/PbrTextureGenerator.java
+++ b/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/PbrTextureGenerator.java
@@ -136,12 +136,12 @@ public class PbrTextureGenerator implements Callable<Integer> {
 
         // We need to write the texture with padding. We can achieve that by offsetting it and writing it in a 2x2 grid
         FloatMask mask = new FloatMask(image_gray, 0L, noSymmetry);
-        FloatMask roughness = new FloatMask(mask.getSize() * 2, 0L, noSymmetry);
-        roughness.setWithOffset(mask, (int) (mask.getSize() * 0.5), (int) (mask.getSize() * 0.5), false, true);
-        roughness.setWithOffset(mask, (int) (mask.getSize() * 1.5), (int) (mask.getSize() * 0.5), false, true);
-        roughness.setWithOffset(mask, (int) (mask.getSize() * 0.5), (int) (mask.getSize() * 1.5), false, true);
-        roughness.setWithOffset(mask, (int) (mask.getSize() * 1.5), (int) (mask.getSize() * 1.5), false, true);
-        return roughness;
+        FloatMask output = new FloatMask(mask.getSize() * 2, 0L, noSymmetry);
+        output.setWithOffset(mask, (int) (mask.getSize() * 0.5), (int) (mask.getSize() * 0.5), false, true);
+        output.setWithOffset(mask, (int) (mask.getSize() * 1.5), (int) (mask.getSize() * 0.5), false, true);
+        output.setWithOffset(mask, (int) (mask.getSize() * 0.5), (int) (mask.getSize() * 1.5), false, true);
+        output.setWithOffset(mask, (int) (mask.getSize() * 1.5), (int) (mask.getSize() * 1.5), false, true);
+        return output;
     }
 
     public enum CompressionType {

--- a/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/PbrTextureGenerator.java
+++ b/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/PbrTextureGenerator.java
@@ -121,7 +121,7 @@ public class PbrTextureGenerator implements Callable<Integer> {
             inputImageSize = imageSize;
             offset = imageSize * 2;
             pbrMask = new Vector4Mask(imageSize * 4, 0L, noSymmetry);
-            pbrMask.set((x, y) -> new Vector4(0.5f, 0.5f, 0.5f, 0.5f));
+            pbrMask.set((x, y) -> new Vector4(127f, 127f, 127f, 127f));
         } else if (imageSize != inputImageSize) {
             throw new RuntimeException("Wrong texture size! Expected " + inputImageSize
                                        + ", but is " + imageSize + ". " +

--- a/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/PbrTextureGenerator.java
+++ b/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/PbrTextureGenerator.java
@@ -7,6 +7,7 @@ import com.faforever.neroxis.map.SymmetrySettings;
 import com.faforever.neroxis.mask.FloatMask;
 import com.faforever.neroxis.mask.Vector4Mask;
 import com.faforever.neroxis.util.ImageUtil;
+import com.faforever.neroxis.util.vector.Vector4;
 import lombok.Getter;
 import lombok.Setter;
 import picocli.CommandLine;
@@ -120,6 +121,7 @@ public class PbrTextureGenerator implements Callable<Integer> {
             inputImageSize = imageSize;
             offset = imageSize * 2;
             pbrMask = new Vector4Mask(imageSize * 4, 0L, noSymmetry);
+            pbrMask.set((x, y) -> new Vector4(0.5f, 0.5f, 0.5f, 0.5f));
         } else if (imageSize != inputImageSize) {
             throw new RuntimeException("Wrong texture size! Expected " + inputImageSize
                                        + ", but is " + imageSize + ". " +


### PR DESCRIPTION
I want to improve the experience when you use the neroxis toolsuite to generate the PBR texture and you don't provide textures for all layers. This can easily be the case when creating a map, when you want to do first tests with only a few textures.
A 0.5 value for heightmaps results in the texture layer behaving almost like the traditional linear interpolation blending. Previously, the 0 value would make the texture layer vanish.
A 0.5 value for roughness results in a surface with noticable reflections, without appearing extremely shiny.
Previously, the 0 value would make the surface look extremely shiny as if it was dripping wet.
