### PR TITLE
Fixes an issue with the visual debugger not being able to display the visual name for a mask.

### DIFF
--- a/shared/src/main/java/com/faforever/neroxis/mask/Mask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/Mask.java
@@ -845,7 +845,6 @@ public abstract sealed class Mask<T, U extends Mask<T, U>> permits OperationsMas
         try {
             U copy = (U) clazz.getDeclaredConstructor(clazz, String.class).newInstance(this, maskName);
             copy.setVisualDebug(isVisualDebug());
-            copy.setVisualName(this.getVisualName());
             return copy;
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException |
                  NoSuchMethodException e) {

--- a/shared/src/main/java/com/faforever/neroxis/mask/Mask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/Mask.java
@@ -845,6 +845,7 @@ public abstract sealed class Mask<T, U extends Mask<T, U>> permits OperationsMas
         try {
             U copy = (U) clazz.getDeclaredConstructor(clazz, String.class).newInstance(this, maskName);
             copy.setVisualDebug(isVisualDebug());
+            copy.setVisualName(this.getVisualName());
             return copy;
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException |
                  NoSuchMethodException e) {

--- a/shared/src/main/java/com/faforever/neroxis/visualization/VisualDebugger.java
+++ b/shared/src/main/java/com/faforever/neroxis/visualization/VisualDebugger.java
@@ -33,6 +33,7 @@ public class VisualDebugger {
 
     public static void visualizeMask(Mask<?, ?> mask, String method, String line, Integer index) {
         Mask<?, ?> copyOfmask = mask.immutableCopy();
+        copyOfmask.setVisualName(mask.getVisualName());
         SwingUtilities.invokeLater(() -> {
                                        createGui();
                                        String name = copyOfmask.getVisualName();


### PR DESCRIPTION
This fix allows the Visual Debugger to display the mask name correctly:
<img width="1529" height="833" alt="image" src="https://github.com/user-attachments/assets/1ef734da-0940-44d7-ad63-b4915b5a42cc" />
