### PR TITLE
Updates to spawnPlacer for LastTerrain's and fixes to symmtry lines.

### DIFF
--- a/generator/src/main/java/com/faforever/neroxis/generator/terrain/FractalNoiseLastTerrainGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/terrain/FractalNoiseLastTerrainGenerator.java
@@ -52,7 +52,7 @@ public class FractalNoiseLastTerrainGenerator extends MultiLevelLastTerrainGener
         waterHeight -= fractalParams.waterHeight();
 
         symmetryLines.setSize(map.getSize() + 1);
-        symmetryLines.drawSymmetryLines();
+        symmetryLines.drawSymmetryLines(symmetrySettings.terrainSymmetry());
     }
 
     @Override
@@ -138,7 +138,7 @@ public class FractalNoiseLastTerrainGenerator extends MultiLevelLastTerrainGener
 
 
         // Blur and add mountains along the line of symmetry
-        if (Set.of(Symmetry.QUAD, Symmetry.DIAG, Symmetry.POINT2, Symmetry.POINT3, Symmetry.POINT4, Symmetry.POINT5,
+        if (Set.of(Symmetry.POINT2, Symmetry.POINT3, Symmetry.POINT4, Symmetry.POINT5,
                    Symmetry.POINT6, Symmetry.POINT7, Symmetry.POINT8, Symmetry.POINT9, Symmetry.POINT10,
                    Symmetry.POINT11, Symmetry.POINT12, Symmetry.POINT13, Symmetry.POINT14, Symmetry.POINT15,
                    Symmetry.POINT16).contains(symmetrySettings.terrainSymmetry())

--- a/generator/src/main/java/com/faforever/neroxis/generator/terrain/MultiLevelLastTerrainGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/terrain/MultiLevelLastTerrainGenerator.java
@@ -121,7 +121,7 @@ public class MultiLevelLastTerrainGenerator extends BasicLastTerrainGenerator {
         switch (waterMask) {
             case WaterMasks.SYMMETRY_LINE:
                 // Water will be more likely along the symmetry line(s), kinda splitting the map in half, or pie slices for odd symmetries
-                waterArea.drawSymmetryLines();
+                waterArea.drawSymmetryLines(symmetrySettings.terrainSymmetry());
                 waterArea.inflate(
                         StrictMath.min(256, mapSize / 4f / symmetrySettings.teamSymmetry().getNumSymPoints()));
                 waterAreaBlur = waterArea.copyAsFloatMask(0f, 1f);
@@ -129,7 +129,7 @@ public class MultiLevelLastTerrainGenerator extends BasicLastTerrainGenerator {
                 break;
             case WaterMasks.HOUR_GLASS:
                 // An unusual shape, which increase the likelihood of water along the symmetry lines and the corners of the map
-                waterArea.drawSymmetryLines();
+                waterArea.drawSymmetryLines(symmetrySettings.terrainSymmetry());
                 waterArea.inflate(mapSize / 4f / symmetrySettings.teamSymmetry().getNumSymPoints());
                 List<Vector2> symmetryPoints = waterArea.getSymmetryPointsWithOutOfBounds(new Vector2(0, 0),
                                                                                           SymmetryType.SPAWN)

--- a/generator/src/test/java/com/faforever/neroxis/generator/MapGeneratorTest.java
+++ b/generator/src/test/java/com/faforever/neroxis/generator/MapGeneratorTest.java
@@ -204,7 +204,7 @@ public class MapGeneratorTest {
     @Test
     public void TestInequalityTournamentStyle() throws Exception {
         MapGenerator instance1 = new MapGenerator(true);
-        new CommandLine(instance1).execute("--tournament-style", "--map-size", "256", "--spawn-count", "2");
+        new CommandLine(instance1).execute("--tournament-style", "--map-size", "512", "--spawn-count", "2");
         SCMap map1 = instance1.getMap();
         long generationTime1 = instance1.getGenerationTime();
         long seed1 = instance1.getBasicOptions().getSeed();
@@ -212,7 +212,7 @@ public class MapGeneratorTest {
         Thread.sleep(1000);
         MapGenerator instance2 = new MapGenerator(true);
 
-        new CommandLine(instance2).execute("--tournament-style", "--seed", String.valueOf(seed1), "--map-size", "256",
+        new CommandLine(instance2).execute("--tournament-style", "--seed", String.valueOf(seed1), "--map-size", "512",
                                            "--spawn-count", "2");
         SCMap map2 = instance2.getMap();
         long generationTime2 = instance2.getGenerationTime();
@@ -268,7 +268,7 @@ public class MapGeneratorTest {
     @Test
     public void TestInequalityBlind() throws Exception {
         MapGenerator instance1 = new MapGenerator(true);
-        new CommandLine(instance1).execute("--blind", "--map-size", "256", "--spawn-count", "2");
+        new CommandLine(instance1).execute("--blind", "--map-size", "512", "--spawn-count", "2");
         SCMap map1 = instance1.getMap();
         long generationTime1 = instance1.getGenerationTime();
         long seed1 = instance1.getBasicOptions().getSeed();
@@ -276,7 +276,7 @@ public class MapGeneratorTest {
         Thread.sleep(1000);
         MapGenerator instance2 = new MapGenerator(true);
 
-        new CommandLine(instance2).execute("--blind", "--seed", String.valueOf(seed1), "--map-size", "256",
+        new CommandLine(instance2).execute("--blind", "--seed", String.valueOf(seed1), "--map-size", "512",
                                            "--spawn-count", "2");
         SCMap map2 = instance2.getMap();
         long generationTime2 = instance2.getGenerationTime();
@@ -331,7 +331,7 @@ public class MapGeneratorTest {
     @Test
     public void TestInequalityUnexplored() throws Exception {
         MapGenerator instance1 = new MapGenerator(true);
-        new CommandLine(instance1).execute("--unexplored", "--map-size", "256", "--spawn-count", "2");
+        new CommandLine(instance1).execute("--unexplored", "--map-size", "512", "--spawn-count", "2");
         SCMap map1 = instance1.getMap();
         long generationTime1 = instance1.getGenerationTime();
         long seed1 = instance1.getBasicOptions().getSeed();
@@ -339,7 +339,7 @@ public class MapGeneratorTest {
         Thread.sleep(1000);
         MapGenerator instance2 = new MapGenerator(true);
 
-        new CommandLine(instance2).execute("--unexplored", "--seed", String.valueOf(seed1), "--map-size", "256",
+        new CommandLine(instance2).execute("--unexplored", "--seed", String.valueOf(seed1), "--map-size", "512",
                                            "--spawn-count", "2");
         SCMap map2 = instance2.getMap();
         long generationTime2 = instance2.getGenerationTime();

--- a/shared/src/main/java/com/faforever/neroxis/map/placement/SpawnPlacer.java
+++ b/shared/src/main/java/com/faforever/neroxis/map/placement/SpawnPlacer.java
@@ -81,10 +81,23 @@ public class SpawnPlacer {
 
     private boolean tryPlaceSpawns(int spawnCount, BooleanMask spawnMask, float teammateSeparation,
                                    int teamSeparation) {
+        Symmetry spawnSymmetry = spawnMask.getSymmetrySettings().spawnSymmetry();
+        int mapSize = map.getSize();
+
+        BooleanMask teamSeparationMask = new BooleanMask(map.getSize() + 1, random.nextLong(),
+                                                         spawnMask.getSymmetrySettings());
+        teamSeparationMask.drawSymmetryLines();
+        if (spawnSymmetry.isPerfectSymmetry()) {
+            teamSeparationMask.inflate(teamSeparation / 2f);
+        } else {
+            teamSeparationMask.inflate((float) teamSeparation / spawnSymmetry.getNumSymPoints())
+                              .fillCircle(mapSize / 2f, mapSize / 2f, mapSize / 4f, true);
+        }
+
         BooleanMask spawnMaskCopy = spawnMask.copy();
-        spawnMaskCopy.fillSides(map.getSize() / spawnCount * 3 / 2, false)
-                     .fillCenter(teamSeparation, false)
-                     .fillEdge(map.getSize() / 32, false)
+        spawnMaskCopy.fillSides(mapSize / spawnCount * 3 / 2, false)
+                     .subtract(teamSeparationMask)
+                     .fillEdge(mapSize / 32, false)
                      .limitToSymmetryRegion();
         Vector2 location = spawnMaskCopy.getRandomPosition();
         while (map.getSpawnCount() < spawnCount) {

--- a/shared/src/main/java/com/faforever/neroxis/map/placement/SpawnPlacer.java
+++ b/shared/src/main/java/com/faforever/neroxis/map/placement/SpawnPlacer.java
@@ -81,23 +81,16 @@ public class SpawnPlacer {
 
     private boolean tryPlaceSpawns(int spawnCount, BooleanMask spawnMask, float teammateSeparation,
                                    int teamSeparation) {
-        Symmetry spawnSymmetry = spawnMask.getSymmetrySettings().spawnSymmetry();
-        int mapSize = map.getSize();
-
-        BooleanMask teamSeparationMask = new BooleanMask(map.getSize() + 1, random.nextLong(),
-                                                         spawnMask.getSymmetrySettings());
-        teamSeparationMask.drawSymmetryLines();
-        if (spawnSymmetry.isPerfectSymmetry()) {
-            teamSeparationMask.inflate(teamSeparation / 2f);
-        } else {
-            teamSeparationMask.inflate((float) teamSeparation / spawnSymmetry.getNumSymPoints())
-                              .fillCircle(mapSize / 2f, mapSize / 2f, mapSize / 4f, true);
-        }
-
         BooleanMask spawnMaskCopy = spawnMask.copy();
-        spawnMaskCopy.fillSides(mapSize / spawnCount * 3 / 2, false)
-                     .subtract(teamSeparationMask)
-                     .fillEdge(mapSize / 32, false)
+        spawnMaskCopy.fillSides(map.getSize() / spawnCount * 3 / 2, false)
+                     .fillCenter(teamSeparation, false)
+                     .subtract(
+                             new BooleanMask(map.getSize() + 1, random.nextLong(), spawnMask.getSymmetrySettings())
+                                     .drawSymmetryLines(spawnMask.getSymmetrySettings().teamSymmetry())
+                                     .inflate((float) teamSeparation / spawnMask.getSymmetrySettings()
+                                                                                .spawnSymmetry()
+                                                                                .getNumSymPoints()))
+                     .fillEdge(map.getSize() / 32, false)
                      .limitToSymmetryRegion();
         Vector2 location = spawnMaskCopy.getRandomPosition();
         while (map.getSpawnCount() < spawnCount) {

--- a/shared/src/main/java/com/faforever/neroxis/mask/BooleanMask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/BooleanMask.java
@@ -800,7 +800,7 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
         }
     }
 
-    public BooleanMask drawSymmetryLines() {
+    public BooleanMask drawSymmetryLines(Symmetry symmetry) {
         return enqueue(() -> {
             int mapSize = getSize();
             int halfX = mapSize + 1 >> 1;
@@ -813,12 +813,20 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
                     drawLine(halfX, halfY, (int) rotated.x(), (int) rotated.y());
                 }
             } else {
-                switch (symmetrySettings.terrainSymmetry()) {
-                    case QUAD, Z, DIAG, POINT2, POINT4, POINT6, POINT8, POINT10, POINT12, POINT14, POINT16 ->
+                switch (symmetry) {
+                    case Z, POINT2, POINT4, POINT6, POINT8, POINT10, POINT12, POINT14, POINT16 ->
                             drawLine(0, halfY, mapSize, halfY);
                     case X -> drawLine(halfX, 0, halfX, mapSize);
                     case XZ -> drawLine(0, 0, mapSize, mapSize);
                     case ZX -> drawLine(0, mapSize, mapSize, 0);
+                    case QUAD -> {
+                        drawLine(0, halfY, mapSize, halfY);
+                        drawLine(halfX, 0, halfX, mapSize);
+                    }
+                    case DIAG -> {
+                        drawLine(0, 0, mapSize, mapSize);
+                        drawLine(0, mapSize, mapSize, 0);
+                    }
                     case POINT3, POINT5, POINT7, POINT9, POINT11, POINT13, POINT15 -> {
                         for (int slice = 0; slice < numSymPoints; slice++) {
                             Vector2 rotated = SymmetryUtil.getRotatedPoint(-mapSize, halfY, mapSize,


### PR DESCRIPTION
As reported by Ravandel:
mapName = "neroxis_map_generator_snapshot_htauvztrkz3kc_bifq";
<img width="1136" height="1143" alt="image" src="https://github.com/user-attachments/assets/f55d35ce-4611-4e02-aff8-45d899707038" />
The `fillCircle()`call in `SpawnPlacer.java:tryPlaceSpawns()` will either draw a symmetry line or a circle.
So the above mapgen is doing this:
<img width="1199" height="678" alt="Current_After_fillCircle" src="https://github.com/user-attachments/assets/25a75686-dae9-4f76-a4a5-ff1a35f2d68b" />
<img width="1194" height="673" alt="Current_After_limitToSymmetryRegion" src="https://github.com/user-attachments/assets/9f09bfeb-5f55-45a3-9e15-d3f3af22f5ee" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Spawn placement now respects symmetry-driven exclusion zones when shaping spawn regions, improving team separation and consistency.
  * Terrain generation uses the selected symmetry to determine mountain/heightmap processing for a narrower set of symmetry types, producing more predictable terrain.
  * Symmetry line drawing expanded and parameterized to include additional symmetry patterns for better visual consistency.

* **Tests**
  * Map-generator tests updated to use larger map size (512).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->