### PR TITLE
Add Brimstone and Remov Styris from random biome pool

### DIFF
--- a/generator/src/main/java/com/faforever/neroxis/generator/style/StyleGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/style/StyleGenerator.java
@@ -21,7 +21,6 @@ import com.faforever.neroxis.generator.texture.MarsTextureGenerator;
 import com.faforever.neroxis.generator.texture.PrayerTextureGenerator;
 import com.faforever.neroxis.generator.texture.StonesTextureGenerator;
 import com.faforever.neroxis.generator.texture.SunsetTextureGenerator;
-import com.faforever.neroxis.generator.texture.SyrtisTextureGenerator;
 import com.faforever.neroxis.generator.texture.TextureGenerator;
 import com.faforever.neroxis.generator.texture.WindingRiverTextureGenerator;
 import com.faforever.neroxis.generator.texture.WonderTextureGenerator;
@@ -74,7 +73,8 @@ public abstract class StyleGenerator implements HasParameterConstraints {
     }
 
     protected WeightedOptionsWithFallback<TextureGenerator> getTextureGeneratorOptions() {
-        return WeightedOptionsWithFallback.of(new DesertTextureGenerator(),
+        return WeightedOptionsWithFallback.of(new BrimstoneTextureGenerator(),
+                                              new WeightedOption<>(new BrimstoneTextureGenerator(), 1f),
                                               new WeightedOption<>(new DesertTextureGenerator(), 1f),
                                               new WeightedOption<>(new EarlyAutumnTextureGenerator(), 1f),
                                               new WeightedOption<>(new FrithenTextureGenerator(), 1f),

--- a/generator/src/main/java/com/faforever/neroxis/generator/style/StyleGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/style/StyleGenerator.java
@@ -74,7 +74,7 @@ public abstract class StyleGenerator implements HasParameterConstraints {
     }
 
     protected WeightedOptionsWithFallback<TextureGenerator> getTextureGeneratorOptions() {
-        return WeightedOptionsWithFallback.of(new BrimstoneTextureGenerator(),
+        return WeightedOptionsWithFallback.of(new DesertTextureGenerator(),
                                               new WeightedOption<>(new DesertTextureGenerator(), 1f),
                                               new WeightedOption<>(new EarlyAutumnTextureGenerator(), 1f),
                                               new WeightedOption<>(new FrithenTextureGenerator(), 1f),
@@ -82,7 +82,6 @@ public abstract class StyleGenerator implements HasParameterConstraints {
                                               new WeightedOption<>(new PrayerTextureGenerator(), 1f),
                                               new WeightedOption<>(new StonesTextureGenerator(), 1f),
                                               new WeightedOption<>(new SunsetTextureGenerator(), 1f),
-                                              new WeightedOption<>(new SyrtisTextureGenerator(), 1f),
                                               new WeightedOption<>(new WindingRiverTextureGenerator(), 1f),
                                               new WeightedOption<>(new WonderTextureGenerator(), 1f),
                                               new WeightedOption<>(new CrystallineTextureGenerator(), 1f));


### PR DESCRIPTION
As per request from Nuggets and Qsff on discord. to remove Red biomes.
This removes Styris from the random biome pool. But it adds Brimstone which I believe was evicted from the random pool.

I set Desert as the new fallback.. because it's my favourite, (I wonder who made it).

Also @Sheikah45 , I don't underastand the Fallback in the WeightedOptions.
When I read the code, it seems impossible for the fallback to ever be used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated terrain texture choices for map generation: an additional Brimstone texture has been added and positioned to increase its prevalence.
  * One existing texture style (Syrtis) has been removed, subtly changing the visual variety of procedurally generated maps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->