### PR TITLE
Fixes the water height for fractal land

### DIFF
--- a/generator/src/main/java/com/faforever/neroxis/generator/terrain/FractalLandLastTerrainGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/terrain/FractalLandLastTerrainGenerator.java
@@ -15,7 +15,7 @@ public class FractalLandLastTerrainGenerator extends FractalNoiseLastTerrainGene
     public void initialize(SCMap map, long seed, GeneratorParameters generatorParameters,
                            SymmetrySettings symmetrySettings, Pipeline pipeline) {
         fractalParams = new FractalParams(
-                0f, FractalWaterMasks.NONE, 1, 1.5f, 8, 2, 4, 22,
+                -5f, FractalWaterMasks.NONE, 1, 1.5f, 8, 2, 4, 22,
                 List.of(
                         new FractalFlattenParams(0, 1, 0, 1, 0.5f, 0, true, true, 4),
                         new FractalFlattenParams(1, 4, 1, 1, 0, 0, false, false, 4),


### PR DESCRIPTION
Fixes and issue with the water height for fractal land.

Bug: Was introduced in version 1.20
I refactored the water height computation (I mis-understood that water height was a propery of the Biome WaterSettings.scmwtr)
So calculation was changed to be relative to the Biome Setting.
But this introduced a bug in Fractal Land where water height can equal the minimum land height.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Adjusted terrain generation parameters to optimize the procedural creation of terrain features in map generation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->