### PR TITLE
Fractal navy updates

### DIFF
--- a/generator/src/main/java/com/faforever/neroxis/generator/FractalFlattenParams.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/FractalFlattenParams.java
@@ -22,6 +22,8 @@ package com.faforever.neroxis.generator;
  *        the edges of plateaus. A value of {@code 0} applies no blur.
  * @param hasRamps
  *        {@code true} if pathable ramps should be generated to the lower layer.
+ * @param rampPercentage
+ *        The percentage of the edge for the layer, that should be ramps, 0.0 to 1.0
  * @param spawnable
  *        {@code true} if spawn points are allowed to generate on this layer.
  * @param spawnMaskDeflate
@@ -36,6 +38,7 @@ public record FractalFlattenParams(
         float slope,
         int edgeBlur,
         boolean hasRamps,
+        float rampPercentage,
         boolean spawnable,
         float spawnMaskDeflate
 ) {}

--- a/generator/src/main/java/com/faforever/neroxis/generator/FractalParams.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/FractalParams.java
@@ -39,6 +39,7 @@ public record FractalParams(
         float waterHeight,
         FractalWaterMasks fractalWaterMask,
         int noiseMapBlurAmount,
+        int noiseSmallestDetail,
         float noiseOctaveMultiplier,
         float noiseExpMultiplier,
         int teamSeparation,

--- a/generator/src/main/java/com/faforever/neroxis/generator/FractalWaterMasks.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/FractalWaterMasks.java
@@ -4,6 +4,6 @@ public enum FractalWaterMasks {
     NONE,
     SYMMETRY_LINE,
     HOUR_GLASS,
-    CENTER_LAKE,
+    LAKE_AROUND_ISLAND,
     SETONS,
 }

--- a/generator/src/main/java/com/faforever/neroxis/generator/MapStyle.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/MapStyle.java
@@ -45,9 +45,9 @@ public enum MapStyle {
     VALLEY(ValleyStyleGenerator::new, 1),
     RIVERS(RiversStyleGenerator::new, 0.25f),
     RIVERS_AND_OCEANS(RiversAndOceansStyleGenerator::new, 0.75f),
-    FRACTAL_LAND(FractalLandStyleGenerator::new, 0.25f),
+    FRACTAL_LAND(FractalLandStyleGenerator::new, 1f),
     FRACTAL_PLATEAU(FractalPlateauStyleGenerator::new, 0.25f),
-    FRACTAL_NAVY(FractalNavyStyleGenerator::new, 0.25f),
+    FRACTAL_NAVY(FractalNavyStyleGenerator::new, 0.75f),
     SETONISH(SetonishStyleGenerator::new, 1f);
 
     private final Supplier<StyleGenerator> generatorSupplier;

--- a/generator/src/main/java/com/faforever/neroxis/generator/terrain/FractalLandLastTerrainGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/terrain/FractalLandLastTerrainGenerator.java
@@ -15,7 +15,7 @@ public class FractalLandLastTerrainGenerator extends FractalNoiseLastTerrainGene
     public void initialize(SCMap map, long seed, GeneratorParameters generatorParameters,
                            SymmetrySettings symmetrySettings, Pipeline pipeline) {
         fractalParams = new FractalParams(
-                0f, FractalWaterMasks.NONE, 1, 1.5f, 8, 2, 4, 22,
+                -5f, FractalWaterMasks.NONE, 1, 1.5f, 8, 2, 4, 22,
                 List.of(
                         new FractalFlattenParams(0, 1, 0, 1, 0.5f, 0, true, true, 4),
                         new FractalFlattenParams(1, 4, 1, 1, 0, 0, false, false, 4),

--- a/generator/src/main/java/com/faforever/neroxis/generator/terrain/FractalLandLastTerrainGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/terrain/FractalLandLastTerrainGenerator.java
@@ -15,13 +15,13 @@ public class FractalLandLastTerrainGenerator extends FractalNoiseLastTerrainGene
     public void initialize(SCMap map, long seed, GeneratorParameters generatorParameters,
                            SymmetrySettings symmetrySettings, Pipeline pipeline) {
         fractalParams = new FractalParams(
-                -5f, FractalWaterMasks.NONE, 1, 1.5f, 8, 2, 4, 22,
+                -5f, FractalWaterMasks.NONE, 1, 2, 1.5f, 8, 2, 4, 22,
                 List.of(
-                        new FractalFlattenParams(0, 1, 0, 1, 0.5f, 0, true, true, 4),
-                        new FractalFlattenParams(1, 4, 1, 1, 0, 0, false, false, 4),
-                        new FractalFlattenParams(4, 6, 13, 13, 0, 2, false, false, 4),
-                        new FractalFlattenParams(6, 15, 11, 11, 0, 0, false, false, 4),
-                        new FractalFlattenParams(15, 22, 16, 16, 0, 1, false, false, 4)
+                        new FractalFlattenParams(0, 1, 0, 1, 0.5f, 0, true,  0.1f, true, 4),
+                        new FractalFlattenParams(1, 4, 1, 1, 0, 0, false, 0f, false, 4),
+                        new FractalFlattenParams(4, 6, 13, 13, 0, 2, false, 0f, false, 4),
+                        new FractalFlattenParams(6, 15, 11, 11, 0, 0, false, 0f, false, 4),
+                        new FractalFlattenParams(15, 22, 16, 16, 0, 1, false, 0f, false, 4)
                 )
         );
 

--- a/generator/src/main/java/com/faforever/neroxis/generator/terrain/FractalNavyLastTerrainGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/terrain/FractalNavyLastTerrainGenerator.java
@@ -1,5 +1,6 @@
 package com.faforever.neroxis.generator.terrain;
 
+import com.faforever.neroxis.brushes.Brushes;
 import com.faforever.neroxis.generator.FractalFlattenParams;
 import com.faforever.neroxis.generator.FractalParams;
 import com.faforever.neroxis.generator.FractalWaterMasks;
@@ -9,6 +10,7 @@ import com.faforever.neroxis.generator.WeightedOptionsWithFallback;
 import com.faforever.neroxis.map.SCMap;
 import com.faforever.neroxis.map.SymmetrySettings;
 import com.faforever.neroxis.map.SymmetryType;
+import com.faforever.neroxis.mask.BooleanMask;
 import com.faforever.neroxis.util.Pipeline;
 import com.faforever.neroxis.util.vector.Vector2;
 
@@ -22,34 +24,34 @@ public class FractalNavyLastTerrainGenerator extends FractalNoiseLastTerrainGene
     @Override
     public void initialize(SCMap map, long seed, GeneratorParameters generatorParameters,
                            SymmetrySettings symmetrySettings, Pipeline pipeline) {
-
         randomWaterMask = WeightedOptionsWithFallback.of(
                 FractalWaterMasks.NONE,
+                new WeightedOption<>(FractalWaterMasks.NONE, 1f),
                 new WeightedOption<>(FractalWaterMasks.SYMMETRY_LINE, 1f),
                 new WeightedOption<>(FractalWaterMasks.HOUR_GLASS, 1f),
-                new WeightedOption<>(FractalWaterMasks.CENTER_LAKE, 1f)
+                new WeightedOption<>(FractalWaterMasks.LAKE_AROUND_ISLAND, 1f)
         ).select(new Random(seed));
 
         if (map.getSize() < 512) {
             // Small maps are very problematic, because of a lack of spawnable land area, and low mex count
             // This increases the area of the map dedicated to spawnable land and mexes
             fractalParams = new FractalParams(
-                    16, randomWaterMask, 2, 1.5f, 5, 2, 4, 50,
+                    15, randomWaterMask, 2, 2, 1.5f, 5, 2, 4, 50,
                     List.of(
-                            new FractalFlattenParams(0f, 0.5f, 0, 8, 0.25f, 0, false, false, 4),
-                            new FractalFlattenParams(0.5f, 1f, 8, 16, 1f, 0, true, false, 4),
-                            new FractalFlattenParams(1f, 27, 18, 18, 0, 1, false, true, 8),
-                            new FractalFlattenParams(27, 50, 18, 35, 1, 1, false, false, 4)
+                            new FractalFlattenParams(0f, 0.5f, 0, 8, 0.25f, 0, false, 0f, false, 4),
+                            new FractalFlattenParams(0.5f, 1f, 8, 16, 1f, 0, true, 0f, false, 4),
+                            new FractalFlattenParams(1f, 27, 18, 18, 0, 1, false, 0.1f, true, 8),
+                            new FractalFlattenParams(27, 50, 18, 35, 1, 1, false, 0f, false, 4)
                             )
             );
         } else {
             // This is a fractal navy map, works well for 10K - 20K maps, with a good amount of the map being ocean.
             fractalParams = new FractalParams(
-                    16, randomWaterMask, 2, 1.5f, 5, 2, 4, 20,
+                    16, randomWaterMask, 2, 2, 1.5f, 5, 2, 4, 20,
                     List.of(
-                            new FractalFlattenParams(0.0f, 3f, 6, 16, 3f, 0, true, false, 4),
-                            new FractalFlattenParams(3f, 27, 18, 18, 0, 1, false, true, 4),
-                            new FractalFlattenParams(27, 50, 18, 35, 1, 1, false, false, 4)
+                            new FractalFlattenParams(0.0f, 3.0f, 6, 6, 1f, 2, true, 0.15f, false, 4),
+                            new FractalFlattenParams(3.0f, 27, 17, 18, 1, 0, false, 0f, true, 4),
+                            new FractalFlattenParams(27, 50, 18, 35, 0.5f, 0, false, 0f, false, 4)
                             )
             );
         }
@@ -58,44 +60,122 @@ public class FractalNavyLastTerrainGenerator extends FractalNoiseLastTerrainGene
     }
 
     @Override
+    protected void setMaxNoiseOctaves() {
+        if (map.getSize() > 768) {
+            maxNoiseOctaves = 8;
+        } else {
+            maxNoiseOctaves = 7;
+        }
+    }
+
+    @Override
     protected void addWaterAreasToNoiseMap(int mapSize) {
+        float waterStength = 1f;
+        int waterBlurRadius = mapSize / 8;
+
         if (randomWaterMask != FractalWaterMasks.NONE) {
             switch (waterMask) {
                 case FractalWaterMasks.SYMMETRY_LINE -> {
                     // Water will be more likely along the symmetry line(s), kinda splitting the map in half, or pie slices for odd symmetries
                     waterArea.drawSymmetryLines(symmetrySettings.terrainSymmetry());
                     waterArea.inflate(
-                            StrictMath.min(256, mapSize / 4f / symmetrySettings.teamSymmetry().getNumSymPoints()));
-                    waterAreaBlur = waterArea.copyAsFloatMask(0f, 1f);
-                    waterAreaBlur.blur(mapSize / 3 / symmetrySettings.teamSymmetry().getNumSymPoints());
+                            StrictMath.min(256, mapSize / 5f / symmetrySettings.teamSymmetry().getNumSymPoints()));
                 }
                 case FractalWaterMasks.HOUR_GLASS -> {
-                    // An unusual shape, which increase the likelihood of water along the symmetry lines and the corners of the map
-                    waterArea.drawSymmetryLines(symmetrySettings.terrainSymmetry());
-                    waterArea.inflate(mapSize / 4f / symmetrySettings.teamSymmetry().getNumSymPoints());
-                    List<Vector2> symmetryPoints = waterArea.getSymmetryPointsWithOutOfBounds(new Vector2(0, 0),
-                                                                                              SymmetryType.SPAWN)
+                    // Big ocean in the centre of the map
+                    waterArea.fillCircle(new Vector2(mapSize / 2f, mapSize / 2f), mapSize / 3f, true);
+
+                    // Make some central island areas
+                    int islandX = mapSize / 3;
+                    int islandY = mapSize / 3;
+                    int randSize = random.nextInt(mapSize / 6, mapSize / 4);
+
+                    List<Vector2> symmetryPoints = waterArea.getSymmetryPointsWithOutOfBounds(
+                                                                    new Vector2(islandX, islandY),
+                                                                    SymmetryType.SPAWN)
                                                             .stream()
                                                             .map(Vector2::roundToNearestHalfPoint)
                                                             .toList();
-                    waterArea.fillCircle(new Vector2(0, 0),
-                                         mapSize / 2f / symmetrySettings.teamSymmetry().getNumSymPoints(), true);
+
+                    waterArea.fillCircle(new Vector2(islandX, islandY), randSize, false);
                     symmetryPoints.forEach(
-                            s -> waterArea.fillCircle(s,
-                                                      mapSize / 2f / symmetrySettings.teamSymmetry().getNumSymPoints(),
-                                                      true));
-                    waterAreaBlur = waterArea.copyAsFloatMask(0f, 1f);
-                    waterAreaBlur.blur(mapSize / 3 / symmetrySettings.teamSymmetry().getNumSymPoints());
+                            s -> waterArea.fillCircle(s, randSize, false)
+                    );
+
+                    waterStength = 2.0f;
                 }
-                case FractalWaterMasks.CENTER_LAKE -> {
-                    // big ocean in the centre of the map
+                case FractalWaterMasks.LAKE_AROUND_ISLAND ->  {
+                    // Big ocean in the centre of the map
                     waterArea.fillCircle(new Vector2(mapSize / 2f, mapSize / 2f), mapSize / 3f, true);
-                    waterAreaBlur = waterArea.copyAsFloatMask(0f, 1f);
-                    waterAreaBlur.blur(mapSize / 8);
+
+                    // Centre Island
+                    waterArea.fillCircle(new Vector2(mapSize / 2f, mapSize / 2f), mapSize / 4.5f, false);
+
+                    waterStength = 2.2f;
+                    waterBlurRadius = mapSize / 16;
                 }
+
             }
+
+            waterAreaBlur = waterArea.copyAsFloatMask(0f, waterStength);
+            waterAreaBlur.blur(waterBlurRadius);
             landNoiseMap.add(1f);
             landNoiseMap.subtract(waterAreaBlur);
         }
     }
+
+    @Override
+    protected void setupMountainHeightmapPipeline() {
+        // Draw some mountains specially implemented for Setons
+        rawMountains.setSize(map.getSize() + 1);
+        String brushName = Brushes.GENERATOR_BRUSHES.get(random.nextInt(Brushes.GENERATOR_BRUSHES.size()));
+
+        float densityMultiplier = 1f / (1024f / map.getSize());
+
+        // Mountains within the main land area
+        rawMountains.useBrushWithinAreaWithDensity(
+                landNoiseMap.copyAsBooleanMask(fractalParams.fractalFlattenParams().get(2).minHeight(),
+                                               fractalParams.fractalFlattenParams().get(2).maxHeight()).deflate(5)
+                , brushName, 25, densityMultiplier, 0.75f, false);
+    }
+
+    @Override
+    protected void blurRamps() {
+        BooleanMask inflatedRamps = ramps.copy();
+
+        heightmap.blur(4, inflatedRamps.copy().inflate(4))
+                 .blur(4, inflatedRamps.copy().inflate(4).outline().inflate(2))
+                 .blur(2, inflatedRamps.copy().inflate(4).outline().inflate(4))
+
+                 .blur(8, inflatedRamps.copy().inflate(8))
+                 .blur(2, inflatedRamps.copy().inflate(8).outline().inflate(4))
+
+                 .blur(16, inflatedRamps.copy().inflate(16))
+                 .blur(2, inflatedRamps.copy().inflate(16).outline().inflate(4))
+
+                 .blur(4, inflatedRamps.copy().inflate(32))
+                 .blur(4, inflatedRamps.copy().inflate(32))
+                 .blur(2, inflatedRamps.copy().inflate(32).outline().inflate(4))
+
+                 .clampMin(0f)
+                 .clampMax(255f);
+    }
+
+    @Override
+    protected int getTeammateSeparation() {
+        // This spaces teammates as far as possible from each other.
+        // On a 20k 4v4 teammates will be 128 apart, making for a better Setons game
+        int numTeams = generatorParameters.numTeams();
+        int spawnsPerTeam = numTeams > 0 ? generatorParameters.spawnCount() / numTeams : 1;
+        if (spawnsPerTeam <= 0) {
+            spawnsPerTeam = 1;
+        }
+        return map.getSize() / 6 / spawnsPerTeam * 4;
+    }
+
+    @Override
+    protected int getTeamSeparation() {
+        return map.getSize() / 3;
+    }
+
 }

--- a/generator/src/main/java/com/faforever/neroxis/generator/terrain/FractalNoiseLastTerrainGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/terrain/FractalNoiseLastTerrainGenerator.java
@@ -32,14 +32,14 @@ public class FractalNoiseLastTerrainGenerator extends MultiLevelLastTerrainGener
         rampNoise = new FloatMask(1, random.nextLong(), symmetrySettings, "rampNoise", pipeline);
         rawMountains = new FloatMask(1, random.nextLong(), symmetrySettings, "rawMountains", pipeline);
 
-        rampNoise.setSize(map.getSize() / 16);
+        rampNoise.setSize((int) (32f * ((float)map.getSize() / 1024)));
         rampNoise.addWhiteNoise(0, 1);
         rampNoise.setSize(map.getSize() + 1);
 
         waterHeight = map.getBiome().waterSettings().elevation();
         waterMask = fractalParams.fractalWaterMask();
 
-        noiseSmallestDetail = 2;
+        noiseSmallestDetail = fractalParams.noiseSmallestDetail();
         noiseOctaveMultiplier = fractalParams.noiseOctaveMultiplier();
 
         noiseMapBlurAmount = fractalParams.noiseMapBlurAmount();
@@ -86,7 +86,7 @@ public class FractalNoiseLastTerrainGenerator extends MultiLevelLastTerrainGener
                 BooleanMask layer = landNoiseMap.copyAsBooleanMask(0f, fractalFlattenParams.maxHeight());
                 layer.outline();
 
-                layer.subtract(rampNoise.copyAsBooleanMask(0f, 0.9f));
+                layer.subtract(rampNoise.copyAsBooleanMask(0f, 1f - fractalFlattenParams.rampPercentage()));
 
                 ramps.add(layer);
             }
@@ -117,11 +117,21 @@ public class FractalNoiseLastTerrainGenerator extends MultiLevelLastTerrainGener
         // Start the land height as the noise map
         heightmapLand.add(landNoiseMap);
 
+        // Flatten the layers
         for (FractalFlattenParams fractalFlattenParams : fractalParams.fractalFlattenParams()) {
             MapMaskMethods.flattenHeightBand(heightmapLand, landNoiseMap, fractalFlattenParams.minHeight(),
                                              fractalFlattenParams.maxHeight(), fractalFlattenParams.destinationMinHeight(),
                                              fractalFlattenParams.destinationMaxHeight(),
-                                             fractalFlattenParams.slope(), fractalFlattenParams.edgeBlur());
+                                             fractalFlattenParams.slope());
+        }
+        // Blur the edge of the layers if applicable
+        for (FractalFlattenParams fractalFlattenParams : fractalParams.fractalFlattenParams()) {
+            if (fractalFlattenParams.edgeBlur() > 0) {
+                BooleanMask flattenMaskOutline = landNoiseMap
+                        .copyAsBooleanMask(fractalFlattenParams.minHeight(), fractalFlattenParams.maxHeight())
+                        .outline().inflate(fractalFlattenParams.edgeBlur());
+                heightmapLand.blur(fractalFlattenParams.edgeBlur(), flattenMaskOutline);
+            }
         }
         heightmap.add(heightmapLand);
 

--- a/generator/src/main/java/com/faforever/neroxis/generator/terrain/FractalPlateauLastTerrainGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/terrain/FractalPlateauLastTerrainGenerator.java
@@ -15,12 +15,12 @@ public class FractalPlateauLastTerrainGenerator extends FractalNoiseLastTerrainG
     public void initialize(SCMap map, long seed, GeneratorParameters generatorParameters,
                            SymmetrySettings symmetrySettings, Pipeline pipeline) {
         fractalParams = new FractalParams(
-                3f, FractalWaterMasks.NONE, 4, 1.2f, 4, 2, 4, 50,
+                3f, FractalWaterMasks.NONE, 4, 2, 1.2f, 4, 2, 4, 50,
                 List.of(
-                        new FractalFlattenParams(0f, 0.1f, 0, 4, 0.5f, 0, false, false, 4),
-                        new FractalFlattenParams(0.1f, 1.0f, 4, 14, 2, 0, true, false, 4),
-                        new FractalFlattenParams(1.0f, 27, 14, 15, 1f, 0, false, true, 4),
-                        new FractalFlattenParams(27, 50, 24, 24, 0, 2, false, false, 4)
+                        new FractalFlattenParams(0f, 0.1f, 0, 4, 0.5f, 0, false, 0f, false, 4),
+                        new FractalFlattenParams(0.1f, 1.0f, 4, 14, 2, 0, true, 0f, false, 4),
+                        new FractalFlattenParams(1.0f, 27, 14, 15, 1f, 0, false, 0.1f, true, 4),
+                        new FractalFlattenParams(27, 50, 24, 24, 0, 2, false, 0f, false, 4)
                 )
         );
 

--- a/generator/src/main/java/com/faforever/neroxis/generator/terrain/MultiLevelLastTerrainGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/terrain/MultiLevelLastTerrainGenerator.java
@@ -22,7 +22,6 @@ public class MultiLevelLastTerrainGenerator extends BasicLastTerrainGenerator {
     protected BooleanMask waterAreaMinusIsland;
     protected BooleanMask bridgeLandArea;
 
-
     protected BooleanMask secondLevelLand;
     protected BooleanMask thirdLevelLand;
 
@@ -30,6 +29,7 @@ public class MultiLevelLastTerrainGenerator extends BasicLastTerrainGenerator {
     protected int noiseSmallestDetail;
     protected float noiseOctaveMultiplier;
     protected int noiseMapBlurAmount;
+    protected int maxNoiseOctaves;
 
     protected int noiseScaleMaxToValue;
     protected float landNoiseMapFirstLevel;
@@ -71,14 +71,17 @@ public class MultiLevelLastTerrainGenerator extends BasicLastTerrainGenerator {
         waterMask = FractalWaterMasks.NONE;
     }
 
+    protected void setMaxNoiseOctaves() {
+        maxNoiseOctaves = 7;
+    }
+
     @Override
     protected void landSetup() {
         int mapSize = map.getSize();
 
-        int MAX_OCTAVES = 7;
+        setMaxNoiseOctaves();
         int numOctaves = 0;
-
-        while (numOctaves < MAX_OCTAVES && noiseSmallestDetail << numOctaves <= mapSize) {
+        while (numOctaves < maxNoiseOctaves && noiseSmallestDetail << numOctaves <= mapSize) {
             numOctaves++;
         }
 

--- a/generator/src/main/java/com/faforever/neroxis/generator/terrain/SetonishLastTerrainGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/terrain/SetonishLastTerrainGenerator.java
@@ -127,7 +127,6 @@ public class SetonishLastTerrainGenerator extends FractalNoiseLastTerrainGenerat
     @Override
     protected void blurRamps() {
         BooleanMask inflatedRamps = ramps.copy().startVisualDebugger();
-        heightmap.startVisualDebugger();
 
         heightmap.blur(4, inflatedRamps.copy().inflate(4))
                  .blur(4, inflatedRamps.copy().inflate(4).outline().inflate(2))

--- a/generator/src/main/java/com/faforever/neroxis/generator/terrain/SetonishLastTerrainGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/terrain/SetonishLastTerrainGenerator.java
@@ -18,18 +18,20 @@ import java.util.List;
 
 public class SetonishLastTerrainGenerator extends FractalNoiseLastTerrainGenerator {
     BooleanMask landBridgeBrush;
+    FloatMask mexDeadZoneNoise;
 
     @Override
     public void initialize(SCMap map, long seed, GeneratorParameters generatorParameters,
                            SymmetrySettings symmetrySettings, Pipeline pipeline) {
         landBridgeBrush = new BooleanMask(1, seed, symmetrySettings, "mapWithBridge", pipeline);
+        mexDeadZoneNoise = new FloatMask(1, seed, symmetrySettings, "mexDeadZoneNoise", pipeline);
 
         fractalParams = new FractalParams(
-                15, FractalWaterMasks.SETONS, 2, 1.5f, 5, 2, 8, 50,
+                15, FractalWaterMasks.SETONS, 4, 4, 1.5f, 5, 2, 8, 50,
                 List.of(
-                        new FractalFlattenParams(0.0f, 3f, 6, 16, 3f, 0, true, false, 4),
-                        new FractalFlattenParams(3f, 30, 16, 16, 2f, 1, false, true, 4),
-                        new FractalFlattenParams(30, 50, 16, 24, 0.5f, 1,  false, false, 4)
+                        new FractalFlattenParams(0.0f, 3f, 6, 16, 8f, 0, true, 0.1f, false, 4),
+                        new FractalFlattenParams(3f, 30, 16, 16, 2f, 1, false, 0.0f, true, 4),
+                        new FractalFlattenParams(30, 50, 16, 24, 0.5f, 1,  false, 0f, false, 4)
                 )
         );
         super.initialize(map, seed, generatorParameters, symmetrySettings, pipeline);
@@ -123,6 +125,29 @@ public class SetonishLastTerrainGenerator extends FractalNoiseLastTerrainGenerat
     }
 
     @Override
+    protected void blurRamps() {
+        BooleanMask inflatedRamps = ramps.copy().startVisualDebugger();
+        heightmap.startVisualDebugger();
+
+        heightmap.blur(4, inflatedRamps.copy().inflate(4))
+                 .blur(4, inflatedRamps.copy().inflate(4).outline().inflate(2))
+                 .blur(2, inflatedRamps.copy().inflate(4).outline().inflate(4))
+
+                 .blur(8, inflatedRamps.copy().inflate(8))
+                 .blur(2, inflatedRamps.copy().inflate(8).outline().inflate(4))
+
+                 .blur(16, inflatedRamps.copy().inflate(16))
+                 .blur(2, inflatedRamps.copy().inflate(16).outline().inflate(4))
+
+                 .blur(4, inflatedRamps.copy().inflate(32))
+                 .blur(4, inflatedRamps.copy().inflate(32))
+                 .blur(2, inflatedRamps.copy().inflate(32).outline().inflate(4))
+
+                 .clampMin(0f)
+                 .clampMax(255f);
+    }
+
+    @Override
     protected void setupMountainHeightmapPipeline() {
         // Draw some mountains specially implemented for Setons
         rawMountains.setSize(map.getSize() + 1);
@@ -207,7 +232,8 @@ public class SetonishLastTerrainGenerator extends FractalNoiseLastTerrainGenerat
                  .fillCenter(map.getSize() / 3, false)
                  .deflate(fractalParams.spawnMaskDeflate());
 
-
-        mexDeadZone.add(bridgeLandArea.copy().subtract(rampNoise.copyAsBooleanMask(0.7f)));
+        mexDeadZoneNoise.setSize(bridgeLandArea.getSize())
+                        .addWhiteNoise(0, 1);
+        mexDeadZone.add(bridgeLandArea.copy().subtract(mexDeadZoneNoise.copyAsBooleanMask(0.7f)));
     }
 }

--- a/shared/src/main/java/com/faforever/neroxis/mask/MapMaskMethods.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/MapMaskMethods.java
@@ -148,11 +148,9 @@ public class MapMaskMethods {
      *              > 1 → slower start, faster rise.
      *              < 1 → faster start, slower rise.
      *              ≤ 0 → uses destinationMaxHeight for entire band.
-     * @param blurAmount the amount of blur to apply at the band edges (0 = no blur)
      * @return the modified FloatMask     */
     public static FloatMask flattenHeightBand(FloatMask exec, FloatMask noiseMap, float minHeight, float maxHeight,
-                                              float destinationMinHeight, float destinationMaxHeight, float slope,
-                                              int blurAmount) {
+                                              float destinationMinHeight, float destinationMaxHeight, float slope) {
         return exec.enqueue(dependencies -> {
            FloatMask noise = (FloatMask) dependencies.getFirst();
            BooleanMask flattenMask = noise.copyAsBooleanMask(minHeight, maxHeight);
@@ -168,9 +166,6 @@ public class MapMaskMethods {
                    return exec.getPrimitive(x, y);
                }
            });
-           if (blurAmount > 0) {
-               exec.blur(blurAmount, flattenMask.outline().inflate(blurAmount));
-           }
         }, noiseMap);
     }
 


### PR DESCRIPTION
A Fix for Fractal Land: (bug introduced in v1.20.0)
- Water height was equal to the minimum land height (so water could bleed onto the map)
- Water height changed to -5 to prevent this

Some changes to the Fractal Navy:
- Water terrain is flat now (also for Setons)
- Rework of the ramp blurring (better now)
- New water patterns and dropped Centre Lake
- Enable noise octive of 8 for Fractal Navy 20K maps, this basically make the random land areas bigger.
- Player spawn locations are more spread out, not as close together
- The Edge Blurring for each Fractal Layer now occurs after all layers are Flattened.
- Some other small tweaks

So the Fractal Navy maps now have these water patterns:
![fractal_navy_maps1_labeled2](https://github.com/user-attachments/assets/60aed058-cc6d-4d9d-b4d6-1050fc232d90)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced terrain generation: improved mountain pipeline, multi-pass ramp blurring, and island-aware water styles
  * Configurable noise octave limits that scale with map size

* **Changes**
  * More precise ramp flattening with edge-aware blurring and adjustable ramp percentage
  * Updated water and map style weightings for varied map layouts
  * Improved spawn separation and terrain detail tuning for small/large maps

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->