### PR TITLE
Small fractal land fixes

### DIFF
--- a/generator/src/main/java/com/faforever/neroxis/generator/terrain/FractalLandLastTerrainGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/terrain/FractalLandLastTerrainGenerator.java
@@ -17,7 +17,8 @@ public class FractalLandLastTerrainGenerator extends FractalNoiseLastTerrainGene
         fractalParams = new FractalParams(
                 -5f, FractalWaterMasks.NONE, 1, 2, 1.5f, 8, 2, 4, 22,
                 List.of(
-                        new FractalFlattenParams(0, 1, 0, 1, 2.5f, 0, true,  0.1f, true, 4),
+                        new FractalFlattenParams(0, 1, 0, 1, 3.5f, 0, true,  0.1f, true, 4),
+                        new FractalFlattenParams(0, 1, 0, 1, 0.5f, 0, true,  0.1f, true, 4),
                         new FractalFlattenParams(1, 4, 1, 1, 0, 0, false, 0f, false, 4),
                         new FractalFlattenParams(4, 6, 13, 13, 0, 2, false, 0f, false, 4),
                         new FractalFlattenParams(6, 15, 11, 11, 0, 0, false, 0f, false, 4),

--- a/generator/src/main/java/com/faforever/neroxis/generator/terrain/FractalLandLastTerrainGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/terrain/FractalLandLastTerrainGenerator.java
@@ -18,7 +18,6 @@ public class FractalLandLastTerrainGenerator extends FractalNoiseLastTerrainGene
                 -5f, FractalWaterMasks.NONE, 1, 2, 1.5f, 8, 2, 4, 22,
                 List.of(
                         new FractalFlattenParams(0, 1, 0, 1, 3.5f, 0, true,  0.1f, true, 4),
-                        new FractalFlattenParams(0, 1, 0, 1, 0.5f, 0, true,  0.1f, true, 4),
                         new FractalFlattenParams(1, 4, 1, 1, 0, 0, false, 0f, false, 4),
                         new FractalFlattenParams(4, 6, 13, 13, 0, 2, false, 0f, false, 4),
                         new FractalFlattenParams(6, 15, 11, 11, 0, 0, false, 0f, false, 4),

--- a/generator/src/main/java/com/faforever/neroxis/generator/terrain/FractalLandLastTerrainGenerator.java
+++ b/generator/src/main/java/com/faforever/neroxis/generator/terrain/FractalLandLastTerrainGenerator.java
@@ -17,7 +17,7 @@ public class FractalLandLastTerrainGenerator extends FractalNoiseLastTerrainGene
         fractalParams = new FractalParams(
                 -5f, FractalWaterMasks.NONE, 1, 2, 1.5f, 8, 2, 4, 22,
                 List.of(
-                        new FractalFlattenParams(0, 1, 0, 1, 0.5f, 0, true,  0.1f, true, 4),
+                        new FractalFlattenParams(0, 1, 0, 1, 2.5f, 0, true,  0.1f, true, 4),
                         new FractalFlattenParams(1, 4, 1, 1, 0, 0, false, 0f, false, 4),
                         new FractalFlattenParams(4, 6, 13, 13, 0, 2, false, 0f, false, 4),
                         new FractalFlattenParams(6, 15, 11, 11, 0, 0, false, 0f, false, 4),
@@ -26,5 +26,14 @@ public class FractalLandLastTerrainGenerator extends FractalNoiseLastTerrainGene
         );
 
         super.initialize(map, seed, generatorParameters, symmetrySettings, pipeline);
+    }
+
+    @Override
+    protected void setMaxNoiseOctaves() {
+        if (map.getSize() > 768) {
+            maxNoiseOctaves = 8;
+        } else {
+            maxNoiseOctaves = 7;
+        }
     }
 }


### PR DESCRIPTION
So some small updates to Fractal Land for the Map Preview. And for 20K maps.

Before: 10K map
<img width="382" height="384" alt="image" src="https://github.com/user-attachments/assets/d2d4a76b-69a7-4db4-885f-e3c5c7755d9c" />

After: 10 map
<img width="384" height="380" alt="image" src="https://github.com/user-attachments/assets/c572f00f-54c7-4266-8be1-7fa8b6d633c4" />


The Noise Octave Change:
20K Map before:
<img width="254" height="255" alt="image" src="https://github.com/user-attachments/assets/bc319cf5-a531-4fa9-938a-500007280ba7" />
20K Map after:
<img width="255" height="253" alt="image" src="https://github.com/user-attachments/assets/b23c45a8-9ee0-43c7-900b-934797918c3a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined terrain flattening parameters to produce more natural and varied landscapes.
  * Adaptive noise-detail scaling based on map size (higher detail for larger maps) for better visual fidelity and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->