### PR TITLE
Remove dodgy forcesymmetry optimisation

### DIFF
--- a/shared/src/main/java/com/faforever/neroxis/mask/Mask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/Mask.java
@@ -504,23 +504,19 @@ public abstract sealed class Mask<T, U extends Mask<T, U>> permits OperationsMas
     }
 
     public U forceSymmetry(SymmetryType symmetryType, boolean reverse) {
-        if (!getSymmetrySettings().terrainSymmetry().isPerfectSymmetry()) {
-            return enqueue(() -> {});
+        if (!reverse) {
+            return applyWithSymmetry(symmetryType, (x, y) -> {
+                T value = get(x, y);
+                applyAtSymmetryPoints(x, y, symmetryType, (sx, sy) -> set(sx, sy, value));
+            });
         } else {
-            if (!reverse) {
-                return applyWithSymmetry(symmetryType, (x, y) -> {
-                    T value = get(x, y);
-                    applyAtSymmetryPoints(x, y, symmetryType, (sx, sy) -> set(sx, sy, value));
-                });
-            } else {
-                if (symmetrySettings.getSymmetry(symmetryType).getNumSymPoints() != 2) {
-                    throw new IllegalArgumentException("Symmetry has more than two symmetry points");
-                }
-                return applyWithSymmetry(symmetryType, (x, y) -> {
-                    List<Vector2> symPoints = getSymmetryPoints(x, y, symmetryType);
-                    symPoints.forEach(symPoint -> set(x, y, get((int) symPoint.x(), (int) symPoint.y())));
-                });
+            if (symmetrySettings.getSymmetry(symmetryType).getNumSymPoints() != 2) {
+                throw new IllegalArgumentException("Symmetry has more than two symmetry points");
             }
+            return applyWithSymmetry(symmetryType, (x, y) -> {
+                List<Vector2> symPoints = getSymmetryPoints(x, y, symmetryType);
+                symPoints.forEach(symPoint -> set(x, y, get((int) symPoint.x(), (int) symPoint.y())));
+            });
         }
     }
 


### PR DESCRIPTION
I dunno... I added this:
```
if (!getSymmetrySettings().terrainSymmetry().isPerfectSymmetry()) {
            return enqueue(() -> {});
}
```
        
I remember it made things soooo much faster on my old laptop.
But yeah, I can't replicate it (maybe it's because I'm on Zen4 now or maybe JDK updates are faster, IDK)

But this optimisation is kinda bad.

Before:
<img width="256" height="256" alt="neroxis_map_generator_snapshot_knm56q2lrunaq_cagqebahaqaagq3e_preview" src="https://github.com/user-attachments/assets/9aae774c-d793-4dc8-93e2-88c5877f9fd9" />


After:
<img width="256" height="256" alt="neroxis_map_generator_snapshot_knm56q2lrunaq_cagqebahaqaagq3e_preview" src="https://github.com/user-attachments/assets/dc191504-109d-4e01-a637-c35dcef0b30c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where forced mask symmetry could be skipped in some cases; symmetry is now consistently applied.
  * Improved reverse-symmetry handling to ensure proper validation of symmetry points and correct mirrored value application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->