### PR TITLE
Add rotation to map resizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ debug/
 debugMap/
 *neroxis_map_generator*
 jmh/
+GeneratedMaps/
+OriginalMaps/
 
 # External tool builders
 .externalToolBuilders/

--- a/shared/src/main/java/com/faforever/neroxis/exporter/ScenarioExporter.java
+++ b/shared/src/main/java/com/faforever/neroxis/exporter/ScenarioExporter.java
@@ -44,10 +44,7 @@ public class ScenarioExporter {
         out.writeBytes("          name = 'FFA',\n");
         out.writeBytes("          armies = {");
         for (Spawn spawn : map.getSpawns()) {
-            out.writeBytes("'" + spawn.getId() + "'");
-            if (map.getSpawns().indexOf(spawn) < map.getSpawns().size() - 1) {
-                out.writeBytes(",");
-            }
+            out.writeBytes("'" + spawn.getId() + "',");
         }
         out.writeBytes("},\n");
         out.writeBytes("        },\n");

--- a/shared/src/main/java/com/faforever/neroxis/importer/ScenarioImporter.java
+++ b/shared/src/main/java/com/faforever/neroxis/importer/ScenarioImporter.java
@@ -9,6 +9,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 public class ScenarioImporter {
@@ -51,13 +52,43 @@ public class ScenarioImporter {
         map.setNoRushRadius((float) noRushRadius);
 
         map.getSpawns().forEach(spawn -> {
-            if (luaScenarioInfo.get("norushoffsetX_" + spawn.getId()) instanceof Lua.Value.Num(double xOffset)
-                && luaScenarioInfo.get("norushoffsetY_" + spawn.getId()) instanceof Lua.Value.Num(
-                    double yOffset
-            )) {
+            if (luaScenarioInfo.get("norushoffsetX_" + spawn.getId()) instanceof Lua.Value.Num(double xOffset) &&
+                luaScenarioInfo.get("norushoffsetY_" + spawn.getId()) instanceof Lua.Value.Num(
+                        double yOffset
+                )) {
                 spawn.setNoRushOffset(new Vector2((float) xOffset, (float) yOffset));
             }
         });
+
+        if (luaScenarioInfo.get("Configurations") instanceof Lua.Value.Table configurations &&
+            configurations.get("standard") instanceof Lua.Value.Table standardTable &&
+            standardTable.get("teams") instanceof Lua.Value.Table teamsTable) {
+            teamsTable.contents()
+                      .values()
+                      .stream()
+                      .filter(Lua.Value.Table.class::isInstance)
+                      .map(Lua.Value.Table.class::cast)
+                      .filter(table -> table.get("name") instanceof Lua.Value.Str(String nameValue) &&
+                                       "FFA".equals(nameValue))
+                      .map(table -> table.get("armies"))
+                      .filter(Lua.Value.Table.class::isInstance)
+                      .map(Lua.Value.Table.class::cast)
+                      .findFirst()
+                      .ifPresent(armiesTable -> {
+                          int numArmies = armiesTable.contents().size();
+                          List<String> armyOrder = IntStream.range(0, numArmies)
+                                                            .mapToObj(i -> switch (armiesTable.get(i + 1)) {
+                                                                case null -> throw new IllegalStateException(
+                                                                        "Count out of range");
+                                                                case Lua.Value.Str(String value) -> value;
+                                                                case Lua.Expression _ ->
+                                                                        throw new IllegalStateException(
+                                                                                "Army is not a string");
+                                                            })
+                                                            .toList();
+                          map.setArmyOrder(armyOrder);
+                      });
+        }
     }
 
     private static boolean isScenarioInfoAssignment(Lua.Statement.Assignment assignment) {

--- a/shared/src/main/java/com/faforever/neroxis/map/AIMarker.java
+++ b/shared/src/main/java/com/faforever/neroxis/map/AIMarker.java
@@ -14,7 +14,7 @@ import java.util.SequencedSet;
 @ToString(callSuper = true)
 @Data
 public final class AIMarker extends Marker {
-    private SequencedSet<String> neighbors;
+    private final SequencedSet<String> neighbors;
 
     public AIMarker(String id, Vector2 position) {
         this(id, new Vector3(position), new LinkedHashSet<>());

--- a/shared/src/main/java/com/faforever/neroxis/map/Decal.java
+++ b/shared/src/main/java/com/faforever/neroxis/map/Decal.java
@@ -12,8 +12,8 @@ import java.util.Locale;
 @ToString(callSuper = true)
 @Data
 public final class Decal extends PositionedObject {
-    private final String path;
-    private final Vector3 rotation;
+    private String path;
+    private Vector3 rotation;
     private Vector3 scale;
     private DecalType type;
     private float cutOffLOD;

--- a/shared/src/main/java/com/faforever/neroxis/map/Prop.java
+++ b/shared/src/main/java/com/faforever/neroxis/map/Prop.java
@@ -10,9 +10,9 @@ import lombok.ToString;
 @ToString(callSuper = true)
 @Data
 public final class Prop extends PositionedObject {
-    private final String path;
-    private final float rotation;
-    private final boolean isBoulder;
+    private String path;
+    private float rotation;
+    private boolean isBoulder;
 
     public Prop(String path, Vector2 position, float rotation, boolean isBoulder) {
         this(path, new Vector3(position), rotation, isBoulder);

--- a/shared/src/main/java/com/faforever/neroxis/map/SCMap.java
+++ b/shared/src/main/java/com/faforever/neroxis/map/SCMap.java
@@ -27,6 +27,10 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.SequencedCollection;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static com.faforever.neroxis.util.ImageUtil.insertImageIntoNewImageOfSize;
 import static com.faforever.neroxis.util.ImageUtil.rotateImage;
@@ -257,6 +261,13 @@ public class SCMap {
 
     public void addArmy(Army army) {
         armies.add(army);
+    }
+
+    public void setArmyOrder(SequencedCollection<String> armyIds) {
+        Map<String, Spawn> spawnsById = spawns.stream()
+                                              .collect(Collectors.toMap(Spawn::getId, Function.identity()));
+        spawns.clear();
+        armyIds.forEach(armyId -> spawns.add(spawnsById.get(armyId)));
     }
 
     public int getBlankCount() {

--- a/shared/src/main/java/com/faforever/neroxis/map/SCMap.java
+++ b/shared/src/main/java/com/faforever/neroxis/map/SCMap.java
@@ -6,6 +6,7 @@ import com.faforever.neroxis.mask.IntegerMask;
 import com.faforever.neroxis.mask.Mask;
 import com.faforever.neroxis.mask.Vector4Mask;
 import com.faforever.neroxis.util.ImageUtil;
+import com.faforever.neroxis.util.serial.biome.LightingSettings;
 import com.faforever.neroxis.util.serial.biome.WaterSettings;
 import com.faforever.neroxis.util.vector.Vector2;
 import com.faforever.neroxis.util.vector.Vector3;
@@ -28,6 +29,7 @@ import java.util.Collection;
 import java.util.List;
 
 import static com.faforever.neroxis.util.ImageUtil.insertImageIntoNewImageOfSize;
+import static com.faforever.neroxis.util.ImageUtil.rotateImage;
 import static com.faforever.neroxis.util.ImageUtil.scaleImage;
 
 @SuppressWarnings("unused")
@@ -126,19 +128,19 @@ public class SCMap {
 
     private static void checkImageSize(BufferedImage image, int size) {
         if (image.getWidth() != size) {
-            throw new IllegalArgumentException("Image size does not match required size: Image size is "
-                                               + image.getWidth()
-                                               + " required size is "
-                                               + size);
+            throw new IllegalArgumentException("Image size does not match required size: Image size is " +
+                                               image.getWidth() +
+                                               " required size is " +
+                                               size);
         }
     }
 
     private static void checkMaskSize(Mask<?, ?> mask, int size) {
         if (mask.getSize() != size) {
-            throw new IllegalArgumentException("Image size does not match required size: Image size is "
-                                               + mask.getSize()
-                                               + " required size is "
-                                               + size);
+            throw new IllegalArgumentException("Image size does not match required size: Image size is " +
+                                               mask.getSize() +
+                                               " required size is " +
+                                               size);
         }
     }
 
@@ -302,6 +304,141 @@ public class SCMap {
         textureMasksLow = scaleImage(textureMasksLow, stratumSize, stratumSize);
     }
 
+    public void rotateMap(float radians) {
+        if ((radians / (float) (StrictMath.PI * 2)) % 1 == 0) {
+            return;
+        }
+
+        rotateMapContent(radians);
+        rotateObjects(radians);
+    }
+
+    private void rotateMapContent(float radians) {
+        rotateBiome(radians);
+
+        heightmap = rotateImage(heightmap, radians);
+        normalMap = rotateImage(normalMap, radians);
+        waterMap = rotateImage(waterMap, radians);
+        waterFoamMap = rotateImage(waterFoamMap, radians);
+        waterShadowMap = rotateImage(waterShadowMap, radians);
+        waterDepthBiasMap = rotateImage(waterDepthBiasMap, radians);
+        terrainType = rotateImage(terrainType, radians);
+        textureMasksHigh = rotateImage(textureMasksHigh, radians);
+        textureMasksLow = rotateImage(textureMasksLow, radians);
+        preview = rotateImage(preview, radians);
+        if (mapNormalTexture != null) {
+            mapNormalTexture = rotateImage(mapNormalTexture, radians);
+        }
+
+        if (mapInfoTexture != null) {
+            mapInfoTexture = rotateImage(mapInfoTexture, radians);
+        }
+    }
+
+    private void rotateBiome(float radians) {
+        WaterSettings oldWaterSettings = this.biome.waterSettings();
+        WaterSettings newWaterSettings = new WaterSettings(oldWaterSettings.waterPresent(),
+                                                           oldWaterSettings.elevation(),
+                                                           oldWaterSettings.elevationDeep(),
+                                                           oldWaterSettings.elevationAbyss(),
+                                                           oldWaterSettings.surfaceColor(),
+                                                           oldWaterSettings.colorLerp(),
+                                                           oldWaterSettings.refractionScale(),
+                                                           oldWaterSettings.fresnelBias(),
+                                                           oldWaterSettings.fresnelPower(),
+                                                           oldWaterSettings.unitReflection(),
+                                                           oldWaterSettings.skyReflection(),
+                                                           oldWaterSettings.sunShininess(),
+                                                           oldWaterSettings.sunStrength(),
+                                                           oldWaterSettings.sunDirection().rotateXZ(radians),
+                                                           oldWaterSettings.sunColor(),
+                                                           oldWaterSettings.sunReflection(), oldWaterSettings.sunGlow(),
+                                                           oldWaterSettings.texPathCubemap(),
+                                                           oldWaterSettings.texPathWaterRamp(),
+                                                           oldWaterSettings.waveTextures()
+                                                                           .stream()
+                                                                           .map(waveTexture -> new WaterSettings.WaveTexture(
+                                                                                   waveTexture.normalMovement()
+                                                                                              .rotate(radians),
+                                                                                   waveTexture.texPath(),
+                                                                                   waveTexture.normalRepeat()))
+                                                                           .toList());
+
+        LightingSettings oldLightingSettings = this.biome.lightingSettings();
+        LightingSettings newLightingSettings = new LightingSettings(oldLightingSettings.lightingMultiplier(),
+                                                                    oldLightingSettings.sunDirection()
+                                                                                       .rotateXZ(radians),
+                                                                    oldLightingSettings.sunAmbience(),
+                                                                    oldLightingSettings.sunColor(),
+                                                                    oldLightingSettings.shadowFillColor(),
+                                                                    oldLightingSettings.specularColor(),
+                                                                    oldLightingSettings.bloom(),
+                                                                    oldLightingSettings.fogColor(),
+                                                                    oldLightingSettings.fogStart(),
+                                                                    oldLightingSettings.fogEnd());
+
+        this.biome = new Biome(this.biome.name(), this.biome.terrainMaterials(), this.biome.propMaterials(),
+                               this.biome.decalMaterials(), newWaterSettings, newLightingSettings);
+    }
+
+    private void rotateObjects(float radians) {
+        rotateObjects(spawns, radians);
+        rotateObjects(airAIMarkers, radians);
+        rotateObjects(amphibiousAIMarkers, radians);
+        rotateObjects(expansionAIMarkers, radians);
+        rotateObjects(largeExpansionAIMarkers, radians);
+        rotateObjects(navalAreaAIMarkers, radians);
+        rotateObjects(navyAIMarkers, radians);
+        rotateObjects(landAIMarkers, radians);
+        rotateObjects(navalRallyMarkers, radians);
+        rotateObjects(rallyMarkers, radians);
+        rotateObjects(blankMarkers, radians);
+        rotateObjects(hydros, radians);
+        rotateObjects(mexes, radians);
+        rotateObjects(props, radians);
+        rotateObjects(decals, radians);
+        rotateObjects(waveGenerators, radians);
+        spawns.forEach(spawn -> spawn.setNoRushOffset(spawn.getNoRushOffset().rotate(radians)));
+        armies.forEach(
+                army -> army.getGroups().forEach(group -> {
+                    rotateObjects(group.getUnits(), radians);
+                    group.getUnits().forEach(unit -> unit.setRotation(unit.getRotation() - radians));
+                }));
+
+        props.forEach(prop -> {
+            prop.setRotation(prop.getRotation() - radians);
+        });
+
+        decals.forEach(decal -> {
+            decal.setRotation(decal.getRotation().rotateXZ(radians));
+            decal.setScale(decal.getScale().rotateXZ(radians));
+        });
+
+        waveGenerators.forEach(waveGenerator -> {
+            waveGenerator.setRotation(waveGenerator.getRotation() - radians);
+            waveGenerator.setVelocity(waveGenerator.getVelocity().rotateXZ(radians));
+        });
+
+        setHeights();
+    }
+
+    private <T extends PositionedObject> void rotateObjects(Collection<T> positionedObjects, float radians) {
+        Vector2 halfPoint = new Vector2(size / 2f, size / 2f);
+
+        Collection<T> repositionedObjects = new ArrayList<>();
+        positionedObjects.forEach(positionedObject -> {
+            Vector2 newPosition = new Vector2(positionedObject.getPosition()).subtract(halfPoint)
+                                                                             .rotate(radians)
+                                                                             .add(halfPoint);
+            positionedObject.setPosition(new Vector3(newPosition));
+            if (ImageUtil.inImageBounds(newPosition, heightmap)) {
+                repositionedObjects.add(positionedObject);
+            }
+        });
+        positionedObjects.clear();
+        positionedObjects.addAll(repositionedObjects);
+    }
+
     public void changeMapSize(int contentSize, int boundsSize, Vector2 boundOffset) {
         int oldSize = size;
         Vector2 topLeftOffset = new Vector2(boundOffset.x() - (float) contentSize / 2,
@@ -324,114 +461,6 @@ public class SCMap {
         if (contentScale != 1 || (boundsScale != 1 && topLeftOffset.x() != 0 && topLeftOffset.y() != 0)) {
             moveObjects(contentScale, topLeftOffset);
         }
-    }
-
-    public void addAmphibiousMarker(AIMarker aiMarker) {
-        amphibiousAIMarkers.add(aiMarker);
-    }
-
-    public int getNavyMarkerCount() {
-        return navyAIMarkers.size();
-    }
-
-    public AIMarker getNavyMarker(int i) {
-        return navyAIMarkers.get(i);
-    }
-
-    public @Nullable AIMarker getNavyMarker(String id) {
-        return navyAIMarkers.stream().filter(navyMarker -> navyMarker.getId().equals(id)).findFirst().orElse(null);
-    }
-
-    public void addNavyMarker(AIMarker aiMarker) {
-        navyAIMarkers.add(aiMarker);
-    }
-
-    public int getAirMarkerCount() {
-        return airAIMarkers.size();
-    }
-
-    public AIMarker getAirMarker(int i) {
-        return airAIMarkers.get(i);
-    }
-
-    public void addAirMarker(AIMarker aiMarker) {
-        airAIMarkers.add(aiMarker);
-    }
-
-    public @Nullable AIMarker getAirMarker(String id) {
-        return airAIMarkers.stream().filter(airMarker -> airMarker.getId().equals(id)).findFirst().orElse(null);
-    }
-
-    public int getRallyMarkerCount() {
-        return rallyMarkers.size();
-    }
-
-    public AIMarker getRallyMarker(int i) {
-        return rallyMarkers.get(i);
-    }
-
-    public void addRallyMarker(AIMarker aiMarker) {
-        rallyMarkers.add(aiMarker);
-    }
-
-    public int getExpansionMarkerCount() {
-        return expansionAIMarkers.size();
-    }
-
-    public AIMarker getExpansionMarker(int i) {
-        return expansionAIMarkers.get(i);
-    }
-
-    public void addExpansionMarker(AIMarker aiMarker) {
-        expansionAIMarkers.add(aiMarker);
-    }
-
-    public int getLargeExpansionMarkerCount() {
-        return largeExpansionAIMarkers.size();
-    }
-
-    public AIMarker getLargeExpansionMarker(int i) {
-        return largeExpansionAIMarkers.get(i);
-    }
-
-    public void addLargeExpansionMarker(AIMarker aiMarker) {
-        largeExpansionAIMarkers.add(aiMarker);
-    }
-
-    public int getNavalAreaMarkerCount() {
-        return navalAreaAIMarkers.size();
-    }
-
-    public AIMarker getNavalAreaMarker(int i) {
-        return navalAreaAIMarkers.get(i);
-    }
-
-    public void addNavalAreaMarker(AIMarker aiMarker) {
-        navalAreaAIMarkers.add(aiMarker);
-    }
-
-    public int getNavyRallyMarkerCount() {
-        return navalRallyMarkers.size();
-    }
-
-    public AIMarker getNavyRallyMarker(int i) {
-        return navalRallyMarkers.get(i);
-    }
-
-    public void addNavyRallyMarker(AIMarker aiMarker) {
-        navalRallyMarkers.add(aiMarker);
-    }
-
-    public int getWaveGeneratorCount() {
-        return waveGenerators.size();
-    }
-
-    public WaveGenerator getWaveGenerator(int i) {
-        return waveGenerators.get(i);
-    }
-
-    public void addWaveGenerator(WaveGenerator waveGenerator) {
-        waveGenerators.add(waveGenerator);
     }
 
     private void scaleMapContent(float contentScale) {
@@ -540,12 +569,9 @@ public class SCMap {
                                                         topLeftOffset.multiply(textureMaskLowScale));
         if (mapNormalTexture != null) {
             float mapNormalTextureScale = (float) mapNormalTexture.getWidth() / size;
-            mapNormalTexture = insertImageIntoNewImageOfSize(mapNormalTexture,
-                                                             StrictMath.round(
-                                                                     mapNormalTexture.getWidth() * boundsScale),
-                                                             StrictMath.round(
-                                                                     mapNormalTexture.getHeight() * boundsScale),
-                                                             topLeftOffset.multiply(mapNormalTextureScale));
+            mapNormalTexture = insertImageIntoNewImageOfSize(mapNormalTexture, StrictMath.round(
+                    mapNormalTexture.getWidth() * boundsScale), StrictMath.round(
+                    mapNormalTexture.getHeight() * boundsScale), topLeftOffset.multiply(mapNormalTextureScale));
         }
         if (mapInfoTexture != null) {
             float mapInfoTextureScale = (float) mapInfoTexture.getWidth() / size;
@@ -557,22 +583,22 @@ public class SCMap {
     }
 
     private void moveObjects(float contentScale, Vector2 offset) {
-        repositionObjects(getSpawns(), contentScale, offset);
-        repositionObjects(getAirAIMarkers(), contentScale, offset);
-        repositionObjects(getAmphibiousAIMarkers(), contentScale, offset);
-        repositionObjects(getExpansionAIMarkers(), contentScale, offset);
-        repositionObjects(getLargeExpansionAIMarkers(), contentScale, offset);
-        repositionObjects(getNavalAreaAIMarkers(), contentScale, offset);
-        repositionObjects(getNavyAIMarkers(), contentScale, offset);
-        repositionObjects(getLandAIMarkers(), contentScale, offset);
-        repositionObjects(getNavalRallyMarkers(), contentScale, offset);
-        repositionObjects(getRallyMarkers(), contentScale, offset);
-        repositionObjects(getBlankMarkers(), contentScale, offset);
-        repositionObjects(getHydros(), contentScale, offset);
-        repositionObjects(getMexes(), contentScale, offset);
-        repositionObjects(getProps(), contentScale, offset);
-        repositionObjects(getDecals(), contentScale, offset);
-        repositionObjects(getWaveGenerators(), contentScale, offset);
+        repositionObjects(spawns, contentScale, offset);
+        repositionObjects(airAIMarkers, contentScale, offset);
+        repositionObjects(amphibiousAIMarkers, contentScale, offset);
+        repositionObjects(expansionAIMarkers, contentScale, offset);
+        repositionObjects(largeExpansionAIMarkers, contentScale, offset);
+        repositionObjects(navalAreaAIMarkers, contentScale, offset);
+        repositionObjects(navyAIMarkers, contentScale, offset);
+        repositionObjects(landAIMarkers, contentScale, offset);
+        repositionObjects(navalRallyMarkers, contentScale, offset);
+        repositionObjects(rallyMarkers, contentScale, offset);
+        repositionObjects(blankMarkers, contentScale, offset);
+        repositionObjects(hydros, contentScale, offset);
+        repositionObjects(mexes, contentScale, offset);
+        repositionObjects(props, contentScale, offset);
+        repositionObjects(decals, contentScale, offset);
+        repositionObjects(waveGenerators, contentScale, offset);
         armies.forEach(
                 army -> army.getGroups().forEach(group -> repositionObjects(group.getUnits(), contentScale, offset)));
 
@@ -608,8 +634,8 @@ public class SCMap {
                 positionedObject.setPosition(new Vector3(position.x(), heightmap.getRaster()
                                                                                 .getPixel((int) position.x(),
                                                                                           (int) position.y(),
-                                                                                          new int[]{0})[0]
-                                                                       * heightMapScale, position.y()));
+                                                                                          new int[]{0})[0] *
+                                                                       heightMapScale, position.y()));
             }
         });
     }
@@ -632,6 +658,115 @@ public class SCMap {
         setObjectHeights(getDecals());
         setObjectHeights(getWaveGenerators());
         armies.forEach(army -> army.getGroups().forEach(group -> setObjectHeights(group.getUnits())));
+    }
+
+
+    public void addAmphibiousMarker(AIMarker aiMarker) {
+        amphibiousAIMarkers.add(aiMarker);
+    }
+
+    public int getNavyMarkerCount() {
+        return navyAIMarkers.size();
+    }
+
+    public AIMarker getNavyMarker(int i) {
+        return navyAIMarkers.get(i);
+    }
+
+    public @Nullable AIMarker getNavyMarker(String id) {
+        return navyAIMarkers.stream().filter(navyMarker -> navyMarker.getId().equals(id)).findFirst().orElse(null);
+    }
+
+    public void addNavyMarker(AIMarker aiMarker) {
+        navyAIMarkers.add(aiMarker);
+    }
+
+    public int getAirMarkerCount() {
+        return airAIMarkers.size();
+    }
+
+    public AIMarker getAirMarker(int i) {
+        return airAIMarkers.get(i);
+    }
+
+    public void addAirMarker(AIMarker aiMarker) {
+        airAIMarkers.add(aiMarker);
+    }
+
+    public @Nullable AIMarker getAirMarker(String id) {
+        return airAIMarkers.stream().filter(airMarker -> airMarker.getId().equals(id)).findFirst().orElse(null);
+    }
+
+    public int getRallyMarkerCount() {
+        return rallyMarkers.size();
+    }
+
+    public AIMarker getRallyMarker(int i) {
+        return rallyMarkers.get(i);
+    }
+
+    public void addRallyMarker(AIMarker aiMarker) {
+        rallyMarkers.add(aiMarker);
+    }
+
+    public int getExpansionMarkerCount() {
+        return expansionAIMarkers.size();
+    }
+
+    public AIMarker getExpansionMarker(int i) {
+        return expansionAIMarkers.get(i);
+    }
+
+    public void addExpansionMarker(AIMarker aiMarker) {
+        expansionAIMarkers.add(aiMarker);
+    }
+
+    public int getLargeExpansionMarkerCount() {
+        return largeExpansionAIMarkers.size();
+    }
+
+    public AIMarker getLargeExpansionMarker(int i) {
+        return largeExpansionAIMarkers.get(i);
+    }
+
+    public void addLargeExpansionMarker(AIMarker aiMarker) {
+        largeExpansionAIMarkers.add(aiMarker);
+    }
+
+    public int getNavalAreaMarkerCount() {
+        return navalAreaAIMarkers.size();
+    }
+
+    public AIMarker getNavalAreaMarker(int i) {
+        return navalAreaAIMarkers.get(i);
+    }
+
+    public void addNavalAreaMarker(AIMarker aiMarker) {
+        navalAreaAIMarkers.add(aiMarker);
+    }
+
+    public int getNavyRallyMarkerCount() {
+        return navalRallyMarkers.size();
+    }
+
+    public AIMarker getNavyRallyMarker(int i) {
+        return navalRallyMarkers.get(i);
+    }
+
+    public void addNavyRallyMarker(AIMarker aiMarker) {
+        navalRallyMarkers.add(aiMarker);
+    }
+
+    public int getWaveGeneratorCount() {
+        return waveGenerators.size();
+    }
+
+    public WaveGenerator getWaveGenerator(int i) {
+        return waveGenerators.get(i);
+    }
+
+    public void addWaveGenerator(WaveGenerator waveGenerator) {
+        waveGenerators.add(waveGenerator);
     }
 
     public void setWaterShadowMap(BufferedImage waterShadowMap) {

--- a/shared/src/main/java/com/faforever/neroxis/map/Unit.java
+++ b/shared/src/main/java/com/faforever/neroxis/map/Unit.java
@@ -10,7 +10,7 @@ import lombok.ToString;
 @ToString(callSuper = true)
 @Data
 public final class Unit extends Marker {
-    private final String type;
+    private String type;
     private float rotation;
 
     public Unit(String id, String type, Vector2 position, float rotation) {

--- a/shared/src/main/java/com/faforever/neroxis/map/WaveGenerator.java
+++ b/shared/src/main/java/com/faforever/neroxis/map/WaveGenerator.java
@@ -9,10 +9,10 @@ import lombok.ToString;
 @ToString(callSuper = true)
 @Data
 public final class WaveGenerator extends PositionedObject {
-    private final String textureName;
-    private final String rampName;
-    private final float rotation;
-    private final Vector3 velocity;
+    private String textureName;
+    private String rampName;
+    private float rotation;
+    private Vector3 velocity;
     private float lifeTimeFirst;
     private float lifeTimeSecond;
     private float periodFirst;

--- a/shared/src/main/java/com/faforever/neroxis/mask/BooleanMask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/BooleanMask.java
@@ -223,24 +223,41 @@ public final class BooleanMask extends PrimitiveMask<Boolean, BooleanMask> {
 
     @Override
     protected BooleanMask setSizeInternal(int newSize) {
-        return enqueue(() -> {
-            int oldSize = getSize();
-            if (oldSize == 1) {
-                boolean value = getPrimitive(0, 0);
-                initializeMask(newSize);
-                fill(value);
-            } else if (oldSize != newSize) {
-                long[] oldMask = mask;
-                initializeMask(newSize);
-                Map<Integer, Integer> coordinateMap = getSymmetricScalingCoordinateMap(oldSize, newSize);
-                applyWithSymmetry(SymmetryType.SPAWN, (x, y) -> {
-                    @SuppressWarnings("NullAway") int newX = coordinateMap.get(x);
-                    @SuppressWarnings("NullAway") int newY = coordinateMap.get(y);
-                    boolean value = getBit(newX, newY, oldSize, oldMask);
-                    applyAtSymmetryPoints(x, y, SymmetryType.SPAWN, (sx, sy) -> setPrimitive(sx, sy, value));
-                });
+        int oldSize = getSize();
+        if (oldSize == 1) {
+            boolean value = getPrimitive(0, 0);
+            initializeMask(newSize);
+            fill(value);
+        } else if (oldSize != newSize) {
+            long[] oldMask = mask;
+            initializeMask(newSize);
+            Map<Integer, Integer> coordinateMap = getSymmetricScalingCoordinateMap(oldSize, newSize);
+            applyWithSymmetry(SymmetryType.SPAWN, (x, y) -> {
+                @SuppressWarnings("NullAway") int newX = coordinateMap.get(x);
+                @SuppressWarnings("NullAway") int newY = coordinateMap.get(y);
+                boolean value = getBit(newX, newY, oldSize, oldMask);
+                applyAtSymmetryPoints(x, y, SymmetryType.SPAWN, (sx, sy) -> setPrimitive(sx, sy, value));
+            });
+        }
+        return this;
+    }
+
+    @Override
+    protected BooleanMask rotateInternal(float radians) {
+        long[] oldMask = mask;
+        int size = getSize();
+        initializeMask(size);
+        applyWithSymmetry(SymmetryType.SPAWN, (x, y) -> {
+            Vector2 rotatedPoint = SymmetryUtil.getRotatedPoint(x, y, size, radians);
+            if (!inBounds(rotatedPoint)) {
+                return;
             }
+            int newX = StrictMath.round(rotatedPoint.x());
+            int newY = StrictMath.round(rotatedPoint.y());
+            boolean value = getBit(newX, newY, size, oldMask);
+            applyAtSymmetryPoints(x, y, SymmetryType.SPAWN, (sx, sy) -> setPrimitive(sx, sy, value));
         });
+        return this;
     }
 
     public boolean getPrimitive(int x, int y) {

--- a/shared/src/main/java/com/faforever/neroxis/mask/FloatMask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/FloatMask.java
@@ -5,6 +5,7 @@ import com.faforever.neroxis.map.Symmetry;
 import com.faforever.neroxis.map.SymmetrySettings;
 import com.faforever.neroxis.map.SymmetryType;
 import com.faforever.neroxis.util.MathUtil;
+import com.faforever.neroxis.util.SymmetryUtil;
 import com.faforever.neroxis.util.functional.BiIntFloatConsumer;
 import com.faforever.neroxis.util.functional.ToFloatBiIntFunction;
 import com.faforever.neroxis.util.vector.Vector;
@@ -32,7 +33,8 @@ import static com.faforever.neroxis.brushes.Brushes.loadBrush;
 public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
     private float[][] mask;
 
-    public FloatMask(int size, RandomGenerator.@Nullable SplittableGenerator random, SymmetrySettings symmetrySettings) {
+    public FloatMask(int size, RandomGenerator.@Nullable SplittableGenerator random,
+                     SymmetrySettings symmetrySettings) {
         this(size, random, symmetrySettings, null);
     }
 
@@ -676,26 +678,43 @@ public final class FloatMask extends PrimitiveMask<Float, FloatMask> {
 
     @Override
     protected FloatMask setSizeInternal(int newSize) {
-        return enqueue(() -> {
-            int oldSize = getSize();
-            if (oldSize == 1) {
-                float value = getPrimitive(0, 0);
-                initializeMask(newSize);
-                fill(value);
-            } else if (oldSize != newSize) {
-                float[][] oldMask = mask;
-                initializeMask(newSize);
-                Map<Integer, Integer> coordinateMap = getSymmetricScalingCoordinateMap(oldSize, newSize);
-                applyWithSymmetry(SymmetryType.SPAWN, (x, y) -> {
-                    @SuppressWarnings("NullAway")
-                    int newX = coordinateMap.get(x);
-                    @SuppressWarnings("NullAway")
-                    int newY = coordinateMap.get(y);
-                    float value = oldMask[newX][newY];
-                    applyAtSymmetryPoints(x, y, SymmetryType.SPAWN, (sx, sy) -> setPrimitive(sx, sy, value));
-                });
+        int oldSize = getSize();
+        if (oldSize == 1) {
+            float value = getPrimitive(0, 0);
+            initializeMask(newSize);
+            fill(value);
+        } else if (oldSize != newSize) {
+            float[][] oldMask = mask;
+            initializeMask(newSize);
+            Map<Integer, Integer> coordinateMap = getSymmetricScalingCoordinateMap(oldSize, newSize);
+            applyWithSymmetry(SymmetryType.SPAWN, (x, y) -> {
+                @SuppressWarnings("NullAway")
+                int newX = coordinateMap.get(x);
+                @SuppressWarnings("NullAway")
+                int newY = coordinateMap.get(y);
+                float value = oldMask[newX][newY];
+                applyAtSymmetryPoints(x, y, SymmetryType.SPAWN, (sx, sy) -> setPrimitive(sx, sy, value));
+            });
+        }
+        return this;
+    }
+
+    @Override
+    protected FloatMask rotateInternal(float radians) {
+        float[][] oldMask = mask;
+        int size = getSize();
+        initializeMask(size);
+        applyWithSymmetry(SymmetryType.SPAWN, (x, y) -> {
+            Vector2 rotatedPoint = SymmetryUtil.getRotatedPoint(x, y, size, radians);
+            if (!inBounds(rotatedPoint)) {
+                return;
             }
+            int newX = StrictMath.round(rotatedPoint.x());
+            int newY = StrictMath.round(rotatedPoint.y());
+            float value = oldMask[newX][newY];
+            applyAtSymmetryPoints(x, y, SymmetryType.SPAWN, (sx, sy) -> setPrimitive(sx, sy, value));
         });
+        return this;
     }
 
     public FloatMask scaleToNewMinAndMaxHeight(float newMin, float newMax) {

--- a/shared/src/main/java/com/faforever/neroxis/mask/IntegerMask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/IntegerMask.java
@@ -2,6 +2,7 @@ package com.faforever.neroxis.mask;
 
 import com.faforever.neroxis.map.SymmetrySettings;
 import com.faforever.neroxis.map.SymmetryType;
+import com.faforever.neroxis.util.SymmetryUtil;
 import com.faforever.neroxis.util.functional.ToIntBiIntFunction;
 import com.faforever.neroxis.util.functional.TriIntConsumer;
 import com.faforever.neroxis.util.vector.Vector2;
@@ -33,7 +34,8 @@ public final class IntegerMask extends PrimitiveMask<Integer, IntegerMask> {
      * @param symmetrySettings symmetrySettings to enforce on the mask
      * @param name             name of the mask
      */
-    public IntegerMask(int size, RandomGenerator.@Nullable SplittableGenerator random, SymmetrySettings symmetrySettings,
+    public IntegerMask(int size, RandomGenerator.@Nullable SplittableGenerator random,
+                       SymmetrySettings symmetrySettings,
                        @Nullable String name) {
         mask = new int[0][0];
         super(size, random, symmetrySettings, name);
@@ -200,26 +202,43 @@ public final class IntegerMask extends PrimitiveMask<Integer, IntegerMask> {
 
     @Override
     protected IntegerMask setSizeInternal(int newSize) {
-        return enqueue(() -> {
-            int oldSize = getSize();
-            if (oldSize == 1) {
-                int value = getPrimitive(0, 0);
-                initializeMask(newSize);
-                fill(value);
-            } else if (oldSize != newSize) {
-                int[][] oldMask = mask;
-                initializeMask(newSize);
-                Map<Integer, Integer> coordinateMap = getSymmetricScalingCoordinateMap(oldSize, newSize);
-                applyWithSymmetry(SymmetryType.SPAWN, (x, y) -> {
-                    @SuppressWarnings("NullAway")
-                    int newX = coordinateMap.get(x);
-                    @SuppressWarnings("NullAway")
-                    int newY = coordinateMap.get(y);
-                    int value = oldMask[newX][newY];
-                    applyAtSymmetryPoints(x, y, SymmetryType.SPAWN, (sx, sy) -> setPrimitive(sx, sy, value));
-                });
+        int oldSize = getSize();
+        if (oldSize == 1) {
+            int value = getPrimitive(0, 0);
+            initializeMask(newSize);
+            fill(value);
+        } else if (oldSize != newSize) {
+            int[][] oldMask = mask;
+            initializeMask(newSize);
+            Map<Integer, Integer> coordinateMap = getSymmetricScalingCoordinateMap(oldSize, newSize);
+            applyWithSymmetry(SymmetryType.SPAWN, (x, y) -> {
+                @SuppressWarnings("NullAway")
+                int newX = coordinateMap.get(x);
+                @SuppressWarnings("NullAway")
+                int newY = coordinateMap.get(y);
+                int value = oldMask[newX][newY];
+                applyAtSymmetryPoints(x, y, SymmetryType.SPAWN, (sx, sy) -> setPrimitive(sx, sy, value));
+            });
+        }
+        return this;
+    }
+
+    @Override
+    protected IntegerMask rotateInternal(float radians) {
+        int[][] oldMask = mask;
+        int size = getSize();
+        initializeMask(size);
+        applyWithSymmetry(SymmetryType.SPAWN, (x, y) -> {
+            Vector2 rotatedPoint = SymmetryUtil.getRotatedPoint(x, y, size, radians);
+            if (!inBounds(rotatedPoint)) {
+                return;
             }
+            int newX = StrictMath.round(rotatedPoint.x());
+            int newY = StrictMath.round(rotatedPoint.y());
+            int value = oldMask[newX][newY];
+            applyAtSymmetryPoints(x, y, SymmetryType.SPAWN, (sx, sy) -> setPrimitive(sx, sy, value));
         });
+        return this;
     }
 
     private int transformAverage(float value) {

--- a/shared/src/main/java/com/faforever/neroxis/mask/Mask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/Mask.java
@@ -143,6 +143,20 @@ public abstract sealed class Mask<T, U extends Mask<T, U>> permits OperationsMas
         }
     }
 
+    /**
+     * Rotates the mask using the given number of radians.
+     *
+     * @param radians angle to rotate the mask
+     * @return the rotated mask
+     */
+    public U rotate(float radians) {
+        if (radians % 360 != 0) {
+            return enqueue(() -> rotateInternal(radians));
+        } else {
+            return (U) this;
+        }
+    }
+
     protected abstract void initializeMask(int size);
 
     protected RandomGenerator.@Nullable SplittableGenerator getNextRandomGenerator() {
@@ -249,6 +263,8 @@ public abstract sealed class Mask<T, U extends Mask<T, U>> permits OperationsMas
     }
 
     protected abstract U setSizeInternal(int newSize);
+
+    protected abstract U rotateInternal(float radians);
 
     public U init(BooleanMask other, T falseValue, T trueValue) {
         plannedSize = other.getSize();
@@ -1070,7 +1086,10 @@ public abstract sealed class Mask<T, U extends Mask<T, U>> permits OperationsMas
             List<Vertex> pts = List.of(v1, v2, v3, v4);
 
             // Compute centroid
-            record Centroid(int cx, int cy) {}
+            record Centroid(
+                    int cx,
+                    int cy
+            ) {}
             Centroid centroid = pts.stream().collect(
                     Collectors.teeing(
                             Collectors.summingInt(Vertex::x),

--- a/shared/src/main/java/com/faforever/neroxis/mask/VectorMask.java
+++ b/shared/src/main/java/com/faforever/neroxis/mask/VectorMask.java
@@ -2,6 +2,7 @@ package com.faforever.neroxis.mask;
 
 import com.faforever.neroxis.map.SymmetrySettings;
 import com.faforever.neroxis.map.SymmetryType;
+import com.faforever.neroxis.util.SymmetryUtil;
 import com.faforever.neroxis.util.functional.BiIntFloatIntConsumer;
 import com.faforever.neroxis.util.functional.ToFloatBiIntFunction;
 import com.faforever.neroxis.util.vector.Vector;
@@ -28,7 +29,8 @@ public abstract sealed class VectorMask<T extends Vector<T>, U extends VectorMas
                                                                                                               Vector4Mask {
     protected T[][] mask;
 
-    public VectorMask(T[][] initialMask, RandomGenerator.@Nullable SplittableGenerator random, SymmetrySettings symmetrySettings,
+    public VectorMask(T[][] initialMask, RandomGenerator.@Nullable SplittableGenerator random,
+                      SymmetrySettings symmetrySettings,
                       @Nullable String name) {
         mask = initialMask;
         super(initialMask.length, random, symmetrySettings, name);
@@ -130,25 +132,41 @@ public abstract sealed class VectorMask<T extends Vector<T>, U extends VectorMas
 
     @Override
     protected U setSizeInternal(int newSize) {
-        return enqueue(() -> {
-            int oldSize = getSize();
-            if (oldSize == 1) {
-                T value = get(0, 0);
-                mask = getNullMask(newSize);
-                fill(value);
-            } else if (oldSize != newSize) {
-                T[][] oldMask = mask;
-                mask = getNullMask(newSize);
-                Map<Integer, Integer> coordinateMap = getSymmetricScalingCoordinateMap(oldSize, newSize);
-                setWithSymmetry(SymmetryType.SPAWN, (x, y) -> {
-                    @SuppressWarnings("NullAway")
-                    int newX = coordinateMap.get(x);
-                    @SuppressWarnings("NullAway")
-                    int newY = coordinateMap.get(y);
-                    return oldMask[newX][newY];
-                });
+        int oldSize = getSize();
+        if (oldSize == 1) {
+            T value = get(0, 0);
+            mask = getNullMask(newSize);
+            fill(value);
+        } else if (oldSize != newSize) {
+            T[][] oldMask = mask;
+            mask = getNullMask(newSize);
+            Map<Integer, Integer> coordinateMap = getSymmetricScalingCoordinateMap(oldSize, newSize);
+            setWithSymmetry(SymmetryType.SPAWN, (x, y) -> {
+                @SuppressWarnings("NullAway")
+                int newX = coordinateMap.get(x);
+                @SuppressWarnings("NullAway")
+                int newY = coordinateMap.get(y);
+                return oldMask[newX][newY];
+            });
+        }
+        return (U) this;
+    }
+
+    @Override
+    protected U rotateInternal(float radians) {
+        T[][] oldMask = mask;
+        int size = getSize();
+        initializeMask(size);
+        setWithSymmetry(SymmetryType.SPAWN, (x, y) -> {
+            Vector2 rotatedPoint = SymmetryUtil.getRotatedPoint(x, y, size, radians);
+            if (!inBounds(rotatedPoint)) {
+                return getZeroValue();
             }
+            int newX = StrictMath.round(rotatedPoint.x());
+            int newY = StrictMath.round(rotatedPoint.y());
+            return oldMask[newX][newY];
         });
+        return (U) this;
     }
 
     protected T[][] getInnerCount() {

--- a/shared/src/main/java/com/faforever/neroxis/util/ImageUtil.java
+++ b/shared/src/main/java/com/faforever/neroxis/util/ImageUtil.java
@@ -73,6 +73,15 @@ public class ImageUtil {
         return imageScaled;
     }
 
+    public static BufferedImage rotateImage(BufferedImage image, float radians) {
+        BufferedImage imageScaled = new BufferedImage(image.getWidth(), image.getHeight(), image.getType());
+        AffineTransform at = new AffineTransform();
+        at.rotate(radians, image.getWidth() / 2d, image.getHeight() / 2d);
+        AffineTransformOp rotateOp = new AffineTransformOp(at, AffineTransformOp.TYPE_BILINEAR);
+        rotateOp.filter(image, imageScaled);
+        return imageScaled;
+    }
+
     public static BufferedImage insertImageIntoNewImageOfSize(BufferedImage image, int width, int height,
                                                               Vector2 locToInsertTopLeft) {
         BufferedImage newImage = new BufferedImage(width, height, image.getType());

--- a/shared/src/main/java/com/faforever/neroxis/util/SymmetryUtil.java
+++ b/shared/src/main/java/com/faforever/neroxis/util/SymmetryUtil.java
@@ -308,29 +308,70 @@ public class SymmetryUtil {
     }
 
     public static Vector2 getRotatedPoint(float x, float y, int size, float radians) {
-        float halfSize = size / 2f;
+        if (radians == 0) {
+            return new Vector2(x, y);
+        }
+        float halfSize = size / 2f - .5f;
 
         // Translate so that center is at origin
-        double xt = x - halfSize;
-        double yt = y - halfSize;
+        float xt = x - halfSize;
+        float yt = y - halfSize;
 
-        double tanHalf = StrictMath.tan(radians / 2.0);
-        double sin = StrictMath.sin(radians);
-
-        // Step 1: shear along x-axis
-        double x1 = StrictMath.round(xt - yt * tanHalf);
-        double y1 = StrictMath.round(yt);
-
-        // Step 2: shear along y-axis
-        double x2 = StrictMath.round(x1);
-        double y2 = StrictMath.round(y1 + x1 * sin);
-
-        // Step 3: shear along x-axis again
-        double xr = StrictMath.round(x2 - y2 * tanHalf);
-        double yr = StrictMath.round(y2);
+        Vector2 result = rotateByShear(radians, xt, yt);
 
         // Translate back
-        return new Vector2((float) (xr + halfSize), (float) (yr + halfSize));
+        return new Vector2(result.x() + halfSize, result.y() + halfSize);
     }
 
+    public static Vector2 rotateByShear(float radians, float xt, float yt) {
+        float sign = StrictMath.signum(radians);
+        if (sign == 0) {
+            return new Vector2(xt, yt);
+        }
+
+        float xs;
+        float ys;
+        float halfPi = (float) (StrictMath.PI / 2);
+        int numNinetyDegreeTurns = StrictMath.round(radians / halfPi);
+        switch (numNinetyDegreeTurns % 4) {
+            case -3, 1 -> {
+                xs = -yt;
+                ys = xt;
+            }
+            case -2, 2 -> {
+                xs = -xt;
+                ys = -yt;
+            }
+            case -1, 3 -> {
+                xs = yt;
+                ys = -xt;
+            }
+            case 0 -> {
+                xs = xt;
+                ys = yt;
+            }
+            default -> throw new IllegalStateException("Unexpected number of 90 degree turns");
+        }
+
+        float residualRadians = radians - numNinetyDegreeTurns * halfPi;
+        if (residualRadians == 0) {
+            return new Vector2(xs, ys);
+        }
+
+        float tanHalf = (float) StrictMath.tan(residualRadians / 2.0);
+        float sin = (float) StrictMath.sin(residualRadians);
+
+        // Step 1: shear along x-axis
+        float x1 = StrictMath.round(xs - ys * tanHalf);
+        float y1 = StrictMath.round(ys);
+
+        // Step 2: shear along y-axis
+        float x2 = StrictMath.round(x1);
+        float y2 = StrictMath.round(y1 + x1 * sin);
+
+        // Step 3: shear along x-axis again
+        float xr = StrictMath.round(x2 - y2 * tanHalf);
+        float yr = StrictMath.round(y2);
+        return new Vector2(xr, yr);
+    }
 }

--- a/shared/src/main/java/com/faforever/neroxis/util/vector/Vector3.java
+++ b/shared/src/main/java/com/faforever/neroxis/util/vector/Vector3.java
@@ -62,6 +62,14 @@ public record Vector3(
         return new Vector3(newX, newY, newZ);
     }
 
+    public Vector3 rotateXZ(float angle) {
+        float oldX = x();
+        float oldZ = z();
+        float cos = (float) StrictMath.cos(angle);
+        float sin = (float) StrictMath.sin(angle);
+        return new Vector3(oldX * cos - oldZ * sin, y(), oldX * sin + oldZ * cos);
+    }
+
     public float getXZDistance(Vector2 location) {
         return getXZDistance(new Vector3(location));
     }

--- a/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/MapForcer.java
+++ b/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/MapForcer.java
@@ -215,21 +215,21 @@ public class MapForcer implements Callable<Integer> {
     }
 
     private void forceMarkers(Collection<Marker> markers) {
-        Collection<Marker> forceedMarkers = new ArrayList<>();
+        Collection<Marker> forcedMarkers = new ArrayList<>();
         markers.forEach(marker -> {
             if (inSourceRegion(marker.getPosition())) {
-                forceedMarkers.add(new Marker(marker.getId(), marker.getPosition()));
+                forcedMarkers.add(new Marker(marker.getId(), marker.getPosition()));
                 List<Vector2> symmetryPoints = heightMask.getSymmetryPointsWithOutOfBounds(marker.getPosition(),
                                                                                            SymmetryType.SPAWN);
                 symmetryPoints.forEach(
-                        symmetryPoint -> forceedMarkers.add(new Marker(marker.getId() + " sym", symmetryPoint)));
+                        symmetryPoint -> forcedMarkers.add(new Marker(marker.getId() + " sym", symmetryPoint)));
             }
         });
-        if (markers.size() == forceedMarkers.size()) {
-            matchToClosestMarkers(markers, forceedMarkers);
+        if (markers.size() == forcedMarkers.size()) {
+            matchToClosestMarkers(markers, forcedMarkers);
         }
         markers.clear();
-        markers.addAll(forceedMarkers);
+        markers.addAll(forcedMarkers);
     }
 
     private void matchToClosestMarkers(Collection<? extends Marker> sourceMarkers,

--- a/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/MapResizer.java
+++ b/toolsuite/src/main/java/com/faforever/neroxis/toolsuite/MapResizer.java
@@ -22,7 +22,13 @@ import static picocli.CommandLine.Mixin;
 import static picocli.CommandLine.Option;
 import static picocli.CommandLine.Spec;
 
-@Command(name = "resize", mixinStandardHelpOptions = true, description = "Change the map size", versionProvider = VersionProvider.class, usageHelpAutoWidth = true)
+@Command(
+        name = "resize",
+        mixinStandardHelpOptions = true,
+        description = "Change the map size",
+        versionProvider = VersionProvider.class,
+        usageHelpAutoWidth = true
+)
 public class MapResizer implements Callable<Integer> {
     @Spec
     private CommandLine.Model.CommandSpec spec;
@@ -32,12 +38,28 @@ public class MapResizer implements Callable<Integer> {
     private OutputFolderMixin outputFolderMixin;
     @Mixin
     private DebugMixin debugMixin;
-    @ArgGroup(exclusive = false, heading = "X and Y coordinate to place the center of the map content, default is the center of the new map size%n")
+    @ArgGroup(
+            exclusive = false,
+            heading = "X and Y coordinate to place the center of the map content, default is the center of the new map size%n"
+    )
     private @Nullable LocationOptions locationOptions;
-    @Option(names = "--map-size", required = true, description = "New map size, can be specified in oGrids (e.g 512) or km (e.g 10km), must result in a power of 2 in oGrids", converter = PowerOfTwoMapSizeConverter.class)
-    private int newMapSize;
-    @Option(names = "--scaled-size", required = true, description = "Size to scale the map content to, can be specified in oGrids (e.g 512) or km (e.g 10km)", converter = MapSizeConverter.class)
-    private int scaledSize;
+    @Option(
+            names = "--map-size",
+            description = "New map size, can be specified in oGrids (e.g 512) or km (e.g 10km), must result in a power of 2 in oGrids default is the current map size",
+            converter = PowerOfTwoMapSizeConverter.class
+    )
+    private Integer newMapSize;
+    @Option(
+            names = "--scaled-size",
+            description = "Size to scale the map content to, can be specified in oGrids (e.g 512) or km (e.g 10km) default is the cuurrent map size",
+            converter = MapSizeConverter.class
+    )
+    private Integer scaledSize;
+    @Option(
+            names = "--rotate",
+            description = "Angle to rotate the map after scaling"
+    )
+    private int angle;
 
     @Override
     public Integer call() throws Exception {
@@ -48,9 +70,16 @@ public class MapResizer implements Callable<Integer> {
     }
 
     private void resizeMap(SCMap map) {
+        if (scaledSize == null) {
+            scaledSize = map.getSize();
+        }
+        if (newMapSize == null) {
+            newMapSize = map.getSize();
+        }
         Vector2 location = locationOptions == null ?
-                           new Vector2(newMapSize / 2f, newMapSize / 2f) :
-                           locationOptions.getLocation();
+                new Vector2(newMapSize / 2f, newMapSize / 2f) :
+                locationOptions.getLocation();
         map.changeMapSize(scaledSize, newMapSize, location);
+        map.rotateMap((float) StrictMath.toRadians(angle));
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added map rotation support for terrain, lighting, water, spawns, markers, props, decals, waves, and units.
  * Added a rotation option to map resizing tools.
  * Map resizing now defaults to the imported map size when size options are omitted.
  * Added support for importing no-rush offsets and preserving free-for-all army order.
  * Added image and vector rotation utilities.

* **Bug Fixes**
  * Improved rotated mask coordinate handling and out-of-bounds behavior.
  * Corrected formatting of exported free-for-all army lists.

* **Chores**
  * Added generated and original map folders to ignored files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->